### PR TITLE
[DRAFT] Use fopen for isFileExistsInternal on android

### DIFF
--- a/core/platform/android/CCFileUtils-android.cpp
+++ b/core/platform/android/CCFileUtils-android.cpp
@@ -107,7 +107,6 @@ bool FileUtilsAndroid::init()
 
 bool FileUtilsAndroid::isFileExistInternal(std::string_view strFilePath) const
 {
-
     DECLARE_GUARD;
 
     if (strFilePath.empty())
@@ -118,10 +117,9 @@ bool FileUtilsAndroid::isFileExistInternal(std::string_view strFilePath) const
     bool bFound = false;
 
     // Check whether file exists in apk.
+    const char* s = strFilePath.data();
     if (strFilePath[0] != '/')
     {
-        const char* s = strFilePath.data();
-
         // Found "assets/" at the beginning of the path and we don't want it
         if (strFilePath.find(_defaultResRootPath) == 0)
             s += _defaultResRootPath.length();
@@ -146,9 +144,12 @@ bool FileUtilsAndroid::isFileExistInternal(std::string_view strFilePath) const
     }
     else
     {
-        struct stat st;
-        if (::stat(strFilePath.data(), &st) == 0)
-            bFound = S_ISREG(st.st_mode);
+        FILE *fp = fopen(s, "r");
+        if (fp)
+        {
+            bFound = true;
+            fclose(fp);
+        }
     }
     return bFound;
 }


### PR DESCRIPTION
I was just profiling my game and realized that isFileExists was appearing in my profile for some reason. Upon digging further, it seems we are using the stat struct to know about the file's existence on android. I changed it back to `fopen` and the profiling showed a great improvement. 

I tested this on an android 10 device (snapdragon 865+) with the project built in release with profiling on. 
Maybe you can also test on other devices.

`Performance with stat`  
![stat](https://user-images.githubusercontent.com/2949958/184145409-07a27a34-d07c-4093-90c6-92680a7ef941.PNG)

`Performance with fopen`  
![fopen](https://user-images.githubusercontent.com/2949958/184145414-f8452a79-27de-480c-a4f3-158693f9a72a.PNG)
