### PR TITLE
Refactor VertexLayout sharing mechanism, fix issue #861

### DIFF
--- a/core/2d/CCAtlasNode.cpp
+++ b/core/2d/CCAtlasNode.cpp
@@ -100,24 +100,6 @@ bool AtlasNode::setProgramState(backend::ProgramState* programState, bool needsR
         pipelineDescriptor.programState = _programState;
         _mvpMatrixLocation              = _programState->getUniformLocation("u_MVPMatrix");
 
-        auto vertexLayout = _programState->getVertexLayout();
-        // a_position
-        vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_POSITION,
-                                   _programState->getAttributeLocation(backend::Attribute::POSITION),
-                                   backend::VertexFormat::FLOAT3, 0, false);
-
-        // a_texCoord
-        vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_TEXCOORD,
-                                   _programState->getAttributeLocation(backend::Attribute::TEXCOORD),
-                                   backend::VertexFormat::FLOAT2, offsetof(V3F_C4B_T2F, texCoords), false);
-
-        // a_color
-        vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_COLOR,
-                                   _programState->getAttributeLocation(backend::Attribute::COLOR),
-                                   backend::VertexFormat::UBYTE4, offsetof(V3F_C4B_T2F, colors), true);
-
-        vertexLayout->setLayout(sizeof(V3F_C4B_T2F));
-
         updateProgramStateTexture(_textureAtlas->getTexture());
         return true;
     }

--- a/core/2d/CCCameraBackgroundBrush.cpp
+++ b/core/2d/CCCameraBackgroundBrush.cpp
@@ -131,28 +131,6 @@ bool CameraBackgroundDepthBrush::init()
     auto& pipelineDescriptor        = _customCommand.getPipelineDescriptor();
     pipelineDescriptor.programState = _programState;
 
-    auto layout               = _programState->getVertexLayout();
-    const auto& attributeInfo = _programState->getProgram()->getActiveAttributes();
-    auto iter                 = attributeInfo.find("a_position");
-    if (iter != attributeInfo.end())
-    {
-        layout->setAttribute("a_position", iter->second.location, backend::VertexFormat::FLOAT3,
-                             offsetof(V3F_C4B_T2F, vertices), false);
-    }
-    iter = attributeInfo.find("a_color");
-    if (iter != attributeInfo.end())
-    {
-        layout->setAttribute("a_color", iter->second.location, backend::VertexFormat::UBYTE4,
-                             offsetof(V3F_C4B_T2F, colors), true);
-    }
-    iter = attributeInfo.find("a_texCoord");
-    if (iter != attributeInfo.end())
-    {
-        layout->setAttribute("a_texCoord", iter->second.location, backend::VertexFormat::FLOAT2,
-                             offsetof(V3F_C4B_T2F, texCoords), true);
-    }
-    layout->setLayout(sizeof(_vertices[0]));
-
     _vertices.resize(4);
     _vertices[0].vertices = Vec3(-1, -1, 0);
     _vertices[1].vertices = Vec3(1, -1, 0);
@@ -403,15 +381,9 @@ bool CameraBackgroundSkyBoxBrush::init()
     _uniformEnvLoc       = _programState->getUniformLocation("u_Env");
 
     auto& pipelineDescriptor        = _customCommand.getPipelineDescriptor();
-    auto layout                     = _programState->getVertexLayout();
     pipelineDescriptor.programState = _programState;
     // disable blend
     pipelineDescriptor.blendDescriptor.blendEnabled = false;
-
-    auto attrNameLoc = _programState->getAttributeLocation(shaderinfos::attribute::ATTRIBUTE_NAME_POSITION);
-    layout->setAttribute(shaderinfos::attribute::ATTRIBUTE_NAME_POSITION, attrNameLoc, backend::VertexFormat::FLOAT3, 0,
-                         false);
-    layout->setLayout(sizeof(Vec3));
 
     initBuffer();
 

--- a/core/2d/CCDrawNode.cpp
+++ b/core/2d/CCDrawNode.cpp
@@ -183,29 +183,6 @@ void DrawNode::freeShaderInternal(CustomCommand& cmd)
 
 void DrawNode::setVertexLayout(CustomCommand& cmd)
 {
-    auto* programState        = cmd.getPipelineDescriptor().programState;
-    auto layout               = programState->getVertexLayout();
-    const auto& attributeInfo = programState->getProgram()->getActiveAttributes();
-    auto iter                 = attributeInfo.find("a_position");
-    if (iter != attributeInfo.end())
-    {
-        layout->setAttribute("a_position", iter->second.location, backend::VertexFormat::FLOAT2, 0, false);
-    }
-
-    iter = attributeInfo.find("a_texCoord");
-    if (iter != attributeInfo.end())
-    {
-        layout->setAttribute("a_texCoord", iter->second.location, backend::VertexFormat::FLOAT2,
-                             offsetof(V2F_C4B_T2F, texCoords), false);
-    }
-
-    iter = attributeInfo.find("a_color");
-    if (iter != attributeInfo.end())
-    {
-        layout->setAttribute("a_color", iter->second.location, backend::VertexFormat::UBYTE4,
-                             offsetof(V2F_C4B_T2F, colors), true);
-    }
-    layout->setLayout(sizeof(V2F_C4B_T2F));
 }
 
 void DrawNode::updateBlendState(CustomCommand& cmd)

--- a/core/2d/CCFastTMXLayer.cpp
+++ b/core/2d/CCFastTMXLayer.cpp
@@ -459,27 +459,7 @@ void FastTMXLayer::updatePrimitives()
                 auto programState = new backend::ProgramState(program);
                 pipelineDescriptor.programState = programState;
             }
-            auto vertexLayout         = pipelineDescriptor.programState->getVertexLayout();
-            const auto& attributeInfo = pipelineDescriptor.programState->getProgram()->getActiveAttributes();
-            auto iterAttribute        = attributeInfo.find("a_position");
-            if (iterAttribute != attributeInfo.end())
-            {
-                vertexLayout->setAttribute("a_position", iterAttribute->second.location, backend::VertexFormat::FLOAT3,
-                                           0, false);
-            }
-            iterAttribute = attributeInfo.find("a_texCoord");
-            if (iterAttribute != attributeInfo.end())
-            {
-                vertexLayout->setAttribute("a_texCoord", iterAttribute->second.location, backend::VertexFormat::FLOAT2,
-                                           offsetof(V3F_C4B_T2F, texCoords), false);
-            }
-            iterAttribute = attributeInfo.find("a_color");
-            if (iterAttribute != attributeInfo.end())
-            {
-                vertexLayout->setAttribute("a_color", iterAttribute->second.location, backend::VertexFormat::UBYTE4,
-                                           offsetof(V3F_C4B_T2F, colors), true);
-            }
-            vertexLayout->setLayout(sizeof(V3F_C4B_T2F));
+
             _mvpMatrixLocaiton = pipelineDescriptor.programState->getUniformLocation("u_MVPMatrix");
             _textureLocation   = pipelineDescriptor.programState->getUniformLocation("u_tex0");
             pipelineDescriptor.programState->setTexture(_textureLocation, 0, _texture->getBackendTexture());

--- a/core/2d/CCGrid.cpp
+++ b/core/2d/CCGrid.cpp
@@ -115,7 +115,6 @@ bool GridBase::initWithSize(const Vec2& gridSize, Texture2D* texture, bool flipp
 #define VERTEX_TEXCOORD_SIZE 2
     uint32_t texcoordOffset   = (VERTEX_POSITION_SIZE) * sizeof(float);
     uint32_t totalSize        = (VERTEX_POSITION_SIZE + VERTEX_TEXCOORD_SIZE) * sizeof(float);
-    auto vertexLayout         = _programState->getVertexLayout();
     const auto& attributeInfo = _programState->getProgram()->getActiveAttributes();
     auto iter                 = attributeInfo.find("a_position");
     if (iter != attributeInfo.end())

--- a/core/2d/CCGrid.cpp
+++ b/core/2d/CCGrid.cpp
@@ -120,15 +120,15 @@ bool GridBase::initWithSize(const Vec2& gridSize, Texture2D* texture, bool flipp
     auto iter                 = attributeInfo.find("a_position");
     if (iter != attributeInfo.end())
     {
-        vertexLayout->setAttribute("a_position", iter->second.location, backend::VertexFormat::FLOAT3, 0, false);
+        _programState->setVertexAttrib("a_position", iter->second.location, backend::VertexFormat::FLOAT3, 0, false);
     }
     iter = attributeInfo.find("a_texCoord");
     if (iter != attributeInfo.end())
     {
-        vertexLayout->setAttribute("a_texCoord", iter->second.location, backend::VertexFormat::FLOAT2, texcoordOffset,
+        _programState->setVertexAttrib("a_texCoord", iter->second.location, backend::VertexFormat::FLOAT2, texcoordOffset,
                                    false);
     }
-    vertexLayout->setLayout(totalSize);
+    _programState->setVertexStride(totalSize);
 
     calculateVertexPoints();
     updateBlendState();

--- a/core/2d/CCLabel.cpp
+++ b/core/2d/CCLabel.cpp
@@ -676,22 +676,6 @@ static Texture2D* _getTexture(Label* label)
 
 void Label::setVertexLayout()
 {
-    auto vertexLayout = _programState->getVertexLayout();
-    /// a_position
-    vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_POSITION,
-                               _programState->getAttributeLocation(backend::Attribute::POSITION),
-                               backend::VertexFormat::FLOAT3, 0, false);
-
-    /// a_texCoord
-    vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_TEXCOORD,
-                               _programState->getAttributeLocation(backend::Attribute::TEXCOORD),
-                               backend::VertexFormat::FLOAT2, offsetof(V3F_C4B_T2F, texCoords), false);
-
-    /// a_color
-    vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_COLOR,
-                               _programState->getAttributeLocation(backend::Attribute::COLOR),
-                               backend::VertexFormat::UBYTE4, offsetof(V3F_C4B_T2F, colors), true);
-    vertexLayout->setLayout(sizeof(V3F_C4B_T2F));
 }
 
 bool Label::setProgramState(backend::ProgramState* programState, bool needsRetain)

--- a/core/2d/CCLayer.cpp
+++ b/core/2d/CCLayer.cpp
@@ -389,15 +389,6 @@ LayerRadialGradient::LayerRadialGradient()
     _radiusLocation     = pipelinePS->getUniformLocation("u_radius");
     _expandLocation     = pipelinePS->getUniformLocation("u_expand");
 
-    auto vertexLayout         = pipelinePS->getVertexLayout();
-    const auto& attributeInfo = pipelinePS->getProgram()->getActiveAttributes();
-    auto iter                 = attributeInfo.find("a_position");
-    if (iter != attributeInfo.end())
-    {
-        vertexLayout->setAttribute("a_position", iter->second.location, backend::VertexFormat::FLOAT2, 0, false);
-    }
-    vertexLayout->setLayout(sizeof(_vertices[0]));
-
     _customCommand.createVertexBuffer(sizeof(_vertices[0]), sizeof(_vertices) / sizeof(_vertices[0]),
                                       CustomCommand::BufferUsage::STATIC);
     _customCommand.setDrawType(CustomCommand::DrawType::ARRAY);

--- a/core/2d/CCMotionStreak.cpp
+++ b/core/2d/CCMotionStreak.cpp
@@ -234,26 +234,26 @@ bool MotionStreak::setProgramState(backend::ProgramState* programState, bool nee
         _mvpMatrixLocaiton = _programState->getUniformLocation("u_MVPMatrix");
         _textureLocation   = _programState->getUniformLocation("u_tex0");
 
-        auto vertexLayout         = _programState->getVertexLayout();
+        // setup custom vertex layout for V2F_T2F_C4B
         const auto& attributeInfo = _programState->getProgram()->getActiveAttributes();
         auto iter                 = attributeInfo.find("a_position");
         if (iter != attributeInfo.end())
         {
-            vertexLayout->setAttribute("a_position", iter->second.location, backend::VertexFormat::FLOAT2, 0, false);
+           _programState->setVertexAttrib("a_position", iter->second.location, backend::VertexFormat::FLOAT2, 0, false);
         }
         iter = attributeInfo.find("a_texCoord");
         if (iter != attributeInfo.end())
         {
-            vertexLayout->setAttribute("a_texCoord", iter->second.location, backend::VertexFormat::FLOAT2,
-                                       2 * sizeof(float), false);
+           _programState->setVertexAttrib("a_texCoord", iter->second.location, backend::VertexFormat::FLOAT2,
+                                      2 * sizeof(float), false);
         }
         iter = attributeInfo.find("a_color");
         if (iter != attributeInfo.end())
         {
-            vertexLayout->setAttribute("a_color", iter->second.location, backend::VertexFormat::UBYTE4,
-                                       4 * sizeof(float), true);
+           _programState->setVertexAttrib("a_color", iter->second.location, backend::VertexFormat::UBYTE4,
+                                      4 * sizeof(float), true);
         }
-        vertexLayout->setLayout(4 * sizeof(float) + 4 * sizeof(uint8_t));
+        _programState->setVertexStride(4 * sizeof(float) + 4 * sizeof(uint8_t));
 
         updateProgramStateTexture(_texture);
         return true;

--- a/core/2d/CCParticleBatchNode.cpp
+++ b/core/2d/CCParticleBatchNode.cpp
@@ -58,27 +58,6 @@ ParticleBatchNode::ParticleBatchNode()
     _mvpMatrixLocaiton = pipelinePS->getUniformLocation("u_MVPMatrix");
     _textureLocation   = pipelinePS->getUniformLocation("u_tex0");
 
-    auto layout               = pipelinePS->getVertexLayout();
-    const auto& attributeInfo = pipelinePS->getProgram()->getActiveAttributes();
-    auto iter                 = attributeInfo.find("a_position");
-    if (iter != attributeInfo.end())
-    {
-        layout->setAttribute("a_position", iter->second.location, backend::VertexFormat::FLOAT3, 0, false);
-    }
-    iter = attributeInfo.find("a_texCoord");
-    if (iter != attributeInfo.end())
-    {
-        layout->setAttribute("a_texCoord", iter->second.location, backend::VertexFormat::FLOAT2,
-                             offsetof(V3F_C4B_T2F, texCoords), false);
-    }
-    iter = attributeInfo.find("a_color");
-    if (iter != attributeInfo.end())
-    {
-        layout->setAttribute("a_color", iter->second.location, backend::VertexFormat::UBYTE4,
-                             offsetof(V3F_C4B_T2F, colors), true);
-    }
-    layout->setLayout(sizeof(V3F_C4B_T2F));
-
     _customCommand.setDrawType(CustomCommand::DrawType::ELEMENT);
     _customCommand.setPrimitiveType(CustomCommand::PrimitiveType::TRIANGLE);
 }

--- a/core/2d/CCParticleSystemQuad.cpp
+++ b/core/2d/CCParticleSystemQuad.cpp
@@ -56,27 +56,6 @@ ParticleSystemQuad::ParticleSystemQuad()
 
     _mvpMatrixLocaiton = pipelinePS->getUniformLocation("u_MVPMatrix");
     _textureLocation   = pipelinePS->getUniformLocation("u_tex0");
-
-    auto vertexLayout         = pipelinePS->getVertexLayout();
-    const auto& attributeInfo = pipelinePS->getProgram()->getActiveAttributes();
-    auto iter                 = attributeInfo.find("a_position");
-    if (iter != attributeInfo.end())
-    {
-        vertexLayout->setAttribute("a_position", iter->second.location, backend::VertexFormat::FLOAT3, 0, false);
-    }
-    iter = attributeInfo.find("a_texCoord");
-    if (iter != attributeInfo.end())
-    {
-        vertexLayout->setAttribute("a_texCoord", iter->second.location, backend::VertexFormat::FLOAT2,
-                                   offsetof(V3F_C4B_T2F, texCoords), false);
-    }
-    iter = attributeInfo.find("a_color");
-    if (iter != attributeInfo.end())
-    {
-        vertexLayout->setAttribute("a_color", iter->second.location, backend::VertexFormat::UBYTE4,
-                                   offsetof(V3F_C4B_T2F, colors), true);
-    }
-    vertexLayout->setLayout(sizeof(V3F_C4B_T2F));
 }
 
 ParticleSystemQuad::~ParticleSystemQuad()

--- a/core/2d/CCProgressTimer.cpp
+++ b/core/2d/CCProgressTimer.cpp
@@ -56,27 +56,16 @@ backend::ProgramState* initPipelineDescriptor(ax::CustomCommand& command,
     AX_SAFE_RELEASE(pipelieDescriptor.programState);
     pipelieDescriptor.programState = programState;
 
-    // set vertexLayout according to V2F_C4B_T2F structure
-    auto vertexLayout         = programState->getVertexLayout();
-    const auto& attributeInfo = programState->getProgram()->getActiveAttributes();
-    auto iter                 = attributeInfo.find("a_position");
-    if (iter != attributeInfo.end())
-    {
-        vertexLayout->setAttribute("a_position", iter->second.location, backend::VertexFormat::FLOAT2, 0, false);
-    }
-    iter = attributeInfo.find("a_texCoord");
-    if (iter != attributeInfo.end())
-    {
-        vertexLayout->setAttribute("a_texCoord", iter->second.location, backend::VertexFormat::FLOAT2,
+    // set custom vertexLayout according to V2F_C4B_T2F structure
+    programState->setVertexAttrib("a_position", program->getAttributeLocation(backend::Attribute::POSITION),
+                                  backend::VertexFormat::FLOAT2, 0, false);
+    programState->setVertexAttrib("a_texCoord", program->getAttributeLocation(backend::Attribute::TEXCOORD),
+                                  backend::VertexFormat::FLOAT2,
                                    offsetof(V2F_C4B_T2F, texCoords), false);
-    }
-    iter = attributeInfo.find("a_color");
-    if (iter != attributeInfo.end())
-    {
-        vertexLayout->setAttribute("a_color", iter->second.location, backend::VertexFormat::UBYTE4,
+    programState->setVertexAttrib("a_color", program->getAttributeLocation(backend::Attribute::COLOR),
+                                  backend::VertexFormat::UBYTE4,
                                    offsetof(V2F_C4B_T2F, colors), true);
-    }
-    vertexLayout->setLayout(sizeof(V2F_C4B_T2F));
+    programState->setVertexStride(sizeof(V2F_C4B_T2F));
 
     if (ridal)
     {

--- a/core/2d/CCSprite.cpp
+++ b/core/2d/CCSprite.cpp
@@ -357,23 +357,6 @@ void Sprite::setTexture(std::string_view filename)
 
 void Sprite::setVertexLayout()
 {
-    // set vertexLayout according to V3F_C4B_T2F structure
-    // auto& vertexLayout = _trianglesCommand.getPipelineDescriptor().vertexLayout;
-    auto vertexLayout = _programState->getVertexLayout();
-    /// a_position
-    vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_POSITION,
-                               _programState->getAttributeLocation(backend::Attribute::POSITION),
-                               backend::VertexFormat::FLOAT3, 0, false);
-    /// a_texCoord
-    vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_TEXCOORD,
-                               _programState->getAttributeLocation(backend::Attribute::TEXCOORD),
-                               backend::VertexFormat::FLOAT2, offsetof(V3F_C4B_T2F, texCoords), false);
-
-    /// a_color
-    vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_COLOR,
-                               _programState->getAttributeLocation(backend::Attribute::COLOR),
-                               backend::VertexFormat::UBYTE4, offsetof(V3F_C4B_T2F, colors), true);
-    vertexLayout->setLayout(sizeof(V3F_C4B_T2F));
 }
 
 void Sprite::setProgramState(uint32_t type)

--- a/core/2d/CCSpriteBatchNode.cpp
+++ b/core/2d/CCSpriteBatchNode.cpp
@@ -124,22 +124,6 @@ void SpriteBatchNode::setUniformLocation()
 void SpriteBatchNode::setVertexLayout()
 {
     AXASSERT(_programState, "programState should not be nullptr");
-    // set vertexLayout according to V3F_C4B_T2F structure
-    auto vertexLayout = _programState->getVertexLayout();
-    /// a_position
-    vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_POSITION,
-                               _programState->getAttributeLocation(backend::Attribute::POSITION),
-                               backend::VertexFormat::FLOAT3, 0, false);
-    /// a_texCoord
-    vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_TEXCOORD,
-                               _programState->getAttributeLocation(backend::Attribute::TEXCOORD),
-                               backend::VertexFormat::FLOAT2, offsetof(V3F_C4B_T2F, texCoords), false);
-
-    /// a_color
-    vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_COLOR,
-                               _programState->getAttributeLocation(backend::Attribute::COLOR),
-                               backend::VertexFormat::UBYTE4, offsetof(V3F_C4B_T2F, colors), true);
-    vertexLayout->setLayout(sizeof(V3F_C4B_T2F));
 }
 
 bool SpriteBatchNode::setProgramState(backend::ProgramState* programState, bool needsRetain)

--- a/core/3d/CCMesh.cpp
+++ b/core/3d/CCMesh.cpp
@@ -352,7 +352,7 @@ void Mesh::setMaterial(Material* material)
                 if (_material->getTechnique()->getName().compare(technique->getName()) == 0)
                 {
                     auto program        = pass->getProgramState()->getProgram();
-                    auto attributes     = program->getActiveAttributes();
+                    auto& attributes     = program->getActiveAttributes();
                     auto meshVertexData = _meshIndexData->getMeshVertexData();
                     auto attributeCount = meshVertexData->getMeshVertexAttribCount();
                     AXASSERT(attributes.size() <= attributeCount, "missing attribute data");

--- a/core/3d/CCMotionStreak3D.cpp
+++ b/core/3d/CCMotionStreak3D.cpp
@@ -141,28 +141,6 @@ void MotionStreak3D::initCustomCommand()
     _customCommand.setPrimitiveType(CustomCommand::PrimitiveType::TRIANGLE_STRIP);
 
     auto& pipelineDescriptor  = _customCommand.getPipelineDescriptor();
-    auto layout               = _programState->getVertexLayout();
-    const auto& attributeInfo = _programState->getProgram()->getActiveAttributes();
-    auto iter                 = attributeInfo.find("a_position");
-    if (iter != attributeInfo.end())
-    {
-        layout->setAttribute("a_position", iter->second.location, backend::VertexFormat::FLOAT3, 0, false);
-    }
-
-    iter = attributeInfo.find("a_color");
-    if (iter != attributeInfo.end())
-    {
-        layout->setAttribute("a_color", iter->second.location, backend::VertexFormat::UBYTE4,
-                             offsetof(VertexData, color), true);
-    }
-
-    iter = attributeInfo.find("a_texCoord");
-    if (iter != attributeInfo.end())
-    {
-        layout->setAttribute("a_texCoord", iter->second.location, backend::VertexFormat::FLOAT2,
-                             offsetof(VertexData, texPos), false);
-    }
-    layout->setLayout(sizeof(VertexData));
 
     auto& blend                  = pipelineDescriptor.blendDescriptor;
     blend.blendEnabled           = true;

--- a/core/3d/CCSkybox.cpp
+++ b/core/3d/CCSkybox.cpp
@@ -68,7 +68,6 @@ bool Skybox::init()
     setProgramState(new backend::ProgramState(program), false);
 
     auto& pipelineDescriptor = _customCommand.getPipelineDescriptor();
-    auto layout              = _programState->getVertexLayout();
 
     pipelineDescriptor.programState = _programState;
     // disable blend

--- a/core/3d/CCSkybox.cpp
+++ b/core/3d/CCSkybox.cpp
@@ -73,14 +73,6 @@ bool Skybox::init()
     pipelineDescriptor.programState = _programState;
     // disable blend
     pipelineDescriptor.blendDescriptor.blendEnabled = false;
-    const auto& attributeInfo                       = _programState->getProgram()->getActiveAttributes();
-    const auto& iter = attributeInfo.find(shaderinfos::attribute::ATTRIBUTE_NAME_POSITION);
-    if (iter != attributeInfo.end())
-    {
-        layout->setAttribute(shaderinfos::attribute::ATTRIBUTE_NAME_POSITION, iter->second.location,
-                             backend::VertexFormat::FLOAT3, 0, false);
-    }
-    layout->setLayout(sizeof(Vec3));
 
     _uniformColorLoc     = _programState->getUniformLocation("u_color");
     _uniformCameraRotLoc = _programState->getUniformLocation("u_cameraRot");

--- a/core/3d/CCTerrain.cpp
+++ b/core/3d/CCTerrain.cpp
@@ -797,27 +797,6 @@ void Terrain::onEnter()
 
 void Terrain::cacheUniformAttribLocation()
 {
-    auto vertexLayout         = _programState->getVertexLayout();
-    const auto& attributeInfo = _programState->getProgram()->getActiveAttributes();
-    auto iter                 = attributeInfo.find("a_position");
-    if (iter != attributeInfo.end())
-    {
-        vertexLayout->setAttribute("a_position", iter->second.location, backend::VertexFormat::FLOAT3, 0, false);
-    }
-    iter = attributeInfo.find("a_texCoord");
-    if (iter != attributeInfo.end())
-    {
-        vertexLayout->setAttribute("a_texCoord", iter->second.location, backend::VertexFormat::FLOAT2,
-                                   offsetof(TerrainVertexData, _texcoord), false);
-    }
-    iter = attributeInfo.find("a_normal");
-    if (iter != attributeInfo.end())
-    {
-        vertexLayout->setAttribute("a_normal", iter->second.location, backend::VertexFormat::FLOAT3,
-                                   offsetof(TerrainVertexData, _normal), false);
-    }
-    vertexLayout->setLayout(sizeof(TerrainVertexData));
-
     _alphaMapLocation.reset();
     for (int i = 0; i < 4; ++i)
     {

--- a/core/3d/CCVertexAttribBinding.cpp
+++ b/core/3d/CCVertexAttribBinding.cpp
@@ -80,13 +80,9 @@ bool VertexAttribBinding::init(MeshIndexData* meshIndexData, Pass* pass, MeshCom
 
     AXASSERT(meshIndexData && pass && pass->getProgramState(), "Invalid arguments");
 
-    auto programState = pass->getProgramState();
-
-    // _vertexLayout = programState->getVertexLayout();
-
     _meshIndexData = meshIndexData;
     _meshIndexData->retain();
-    _programState = programState;
+    _programState = pass->getProgramState();
     _programState->retain();
 
     auto meshVertexData = meshIndexData->getMeshVertexData();

--- a/core/3d/CCVertexAttribBinding.cpp
+++ b/core/3d/CCVertexAttribBinding.cpp
@@ -31,7 +31,7 @@ NS_AX_BEGIN
 
 static std::vector<VertexAttribBinding*> __vertexAttribBindingCache;
 
-VertexAttribBinding::VertexAttribBinding() : _meshIndexData(nullptr), _programState(nullptr), _attributes() {}
+VertexAttribBinding::VertexAttribBinding() : _meshIndexData(nullptr), _programState(nullptr) {}
 
 VertexAttribBinding::~VertexAttribBinding()
 {
@@ -45,7 +45,6 @@ VertexAttribBinding::~VertexAttribBinding()
 
     AX_SAFE_RELEASE(_meshIndexData);
     AX_SAFE_RELEASE(_programState);
-    _attributes.clear();
 }
 
 VertexAttribBinding* VertexAttribBinding::create(MeshIndexData* meshIndexData, Pass* pass, MeshCommand* command)
@@ -115,23 +114,21 @@ void VertexAttribBinding::parseAttributes()
 {
     AXASSERT(_programState, "invalid glprogram");
 
-    _attributes.clear();
     _vertexAttribsFlags = 0;
-
-    auto program = _programState->getProgram();
-    _attributes  = program->getActiveAttributes();
 }
 
 bool VertexAttribBinding::hasAttribute(const shaderinfos::VertexKey& key) const
 {
     auto& name = shaderinfos::getAttributeName(key);
-    return _attributes.find(name) != _attributes.end();
+    auto& attributes = _programState->getProgram()->getActiveAttributes();
+    return attributes.find(name) != attributes.end();
 }
 
-backend::AttributeBindInfo* VertexAttribBinding::getVertexAttribValue(std::string_view name)
+const backend::AttributeBindInfo* VertexAttribBinding::getVertexAttribValue(std::string_view name)
 {
-    const auto itr = _attributes.find(name);
-    if (itr != _attributes.end())
+    auto& attributes = _programState->getProgram()->getActiveAttributes();
+    const auto itr = attributes.find(name);
+    if (itr != attributes.end())
         return &itr->second;
     return nullptr;
 }

--- a/core/3d/CCVertexAttribBinding.cpp
+++ b/core/3d/CCVertexAttribBinding.cpp
@@ -82,7 +82,7 @@ bool VertexAttribBinding::init(MeshIndexData* meshIndexData, Pass* pass, MeshCom
 
     auto programState = pass->getProgramState();
 
-    _vertexLayout = programState->getVertexLayout();
+    // _vertexLayout = programState->getVertexLayout();
 
     _meshIndexData = meshIndexData;
     _meshIndexData->retain();
@@ -103,7 +103,7 @@ bool VertexAttribBinding::init(MeshIndexData* meshIndexData, Pass* pass, MeshCom
         offset += meshattribute.getAttribSizeBytes();
     }
 
-    _vertexLayout->setLayout(offset);
+    _programState->setVertexStride(offset);
 
     AXASSERT(offset == meshVertexData->getSizePerVertex(), "vertex layout mismatch!");
 
@@ -150,7 +150,7 @@ void VertexAttribBinding::setVertexAttribPointer(std::string_view name,
     if (v)
     {
         // AXLOG("axys: set attribute '%s' location: %d, offset: %d", name.c_str(), v->location, offset);
-        _vertexLayout->setAttribute(name, v->location, type, offset, normalized);
+        _programState->setVertexAttrib(name, v->location, type, offset, normalized);
         _vertexAttribsFlags |= flag;
     }
     else

--- a/core/3d/CCVertexAttribBinding.h
+++ b/core/3d/CCVertexAttribBinding.h
@@ -112,12 +112,11 @@ private:
                                 bool normalized,
                                 int offset,
                                 int flag);
-    backend::AttributeBindInfo* getVertexAttribValue(std::string_view name);
+    const backend::AttributeBindInfo* getVertexAttribValue(std::string_view name);
     void parseAttributes();
 
     MeshIndexData* _meshIndexData;
     backend::ProgramState* _programState;
-    hlookup::string_map<backend::AttributeBindInfo> _attributes;
     uint32_t _vertexAttribsFlags;
 };
 

--- a/core/3d/CCVertexAttribBinding.h
+++ b/core/3d/CCVertexAttribBinding.h
@@ -117,7 +117,6 @@ private:
 
     MeshIndexData* _meshIndexData;
     backend::ProgramState* _programState;
-    std::shared_ptr<backend::VertexLayout> _vertexLayout = std::make_shared<backend::VertexLayout>();
     hlookup::string_map<backend::AttributeBindInfo> _attributes;
     uint32_t _vertexAttribsFlags;
 };

--- a/core/base/CCStencilStateManager.cpp
+++ b/core/base/CCStencilStateManager.cpp
@@ -40,15 +40,6 @@ StencilStateManager::StencilStateManager()
     _programState                   = new backend::ProgramState(program);
     pipelineDescriptor.programState = _programState;
 
-    auto vertexLayout         = _programState->getVertexLayout();
-    const auto& attributeInfo = _programState->getProgram()->getActiveAttributes();
-    auto iter                 = attributeInfo.find("a_position");
-    if (iter != attributeInfo.end())
-    {
-        vertexLayout->setAttribute("a_position", iter->second.location, backend::VertexFormat::FLOAT2, 0, false);
-    }
-    vertexLayout->setLayout(2 * sizeof(float));
-
     _mvpMatrixLocaiton    = pipelineDescriptor.programState->getUniformLocation("u_MVPMatrix");
     _colorUniformLocation = pipelineDescriptor.programState->getUniformLocation("u_color");
 

--- a/core/base/ccTypes.h
+++ b/core/base/ccTypes.h
@@ -390,6 +390,26 @@ struct AX_DLL V3F_C4F
     Color4F colors;
 };
 
+struct V3F_C4B
+{
+    Vec3 vertices;
+    Color4B colors;
+};
+
+struct V3F_T2F_C4F
+{
+    Vec3 position;
+    Vec2 uv;
+    Vec4 color;
+};
+
+struct V3F_T2F_N3F
+{
+    Vec3 position;
+    Tex2F texcoord;
+    Vec3 normal;
+};
+
 /** @struct V2F_C4B_T2F_Triangle
  * A Triangle of V2F_C4B_T2F.
  */

--- a/core/navmesh/CCNavMeshDebugDraw.cpp
+++ b/core/navmesh/CCNavMeshDebugDraw.cpp
@@ -41,13 +41,6 @@ NavMeshDebugDraw::NavMeshDebugDraw()
     auto* program = backend::Program::getBuiltinProgram(backend::ProgramType::POSITION_COLOR);
     _programState = new backend::ProgramState(program);
     _locMVP       = _programState->getUniformLocation("u_MVPMatrix");
-
-    auto vertexLayout = _programState->getVertexLayout();
-    vertexLayout->setAttribute("a_position", _programState->getAttributeLocation("a_position"),
-                               backend::VertexFormat::FLOAT3, offsetof(V3F_C4F, position), false);
-    vertexLayout->setAttribute("a_color", _programState->getAttributeLocation("a_color"), backend::VertexFormat::FLOAT4,
-                               offsetof(V3F_C4F, color), false);
-    vertexLayout->setLayout(sizeof(V3F_C4F));
 }
 
 void NavMeshDebugDraw::initCustomCommand(CustomCommand& command)

--- a/core/physics3d/CCPhysics3DDebugDrawer.cpp
+++ b/core/physics3d/CCPhysics3DDebugDrawer.cpp
@@ -132,17 +132,6 @@ void Physics3DDebugDrawer::init()
     _programState = new backend::ProgramState(program);
     _locMVP       = _programState->getUniformLocation("u_MVPMatrix");
 
-    auto attributes  = _programState->getProgram()->getActiveAttributes();
-    auto locPosition = attributes["a_position"];
-    auto locColor    = attributes["a_color"];
-
-    auto layout = _programState->getVertexLayout();
-    layout->setAttribute(locPosition.attributeName.c_str(), locPosition.location, backend::VertexFormat::FLOAT3,
-                         offsetof(V3F_V4F, vertex), false);
-    layout->setAttribute(locColor.attributeName.c_str(), locColor.location, backend::VertexFormat::FLOAT4,
-                         offsetof(V3F_V4F, color), false);
-    layout->setLayout(sizeof(V3F_V4F));
-
     _buffer.reserve(512);
 
     _customCommand.getPipelineDescriptor().programState = _programState;

--- a/core/renderer/CCTexture2D.cpp
+++ b/core/renderer/CCTexture2D.cpp
@@ -739,20 +739,6 @@ void Texture2D::initProgram()
 
     pipelineDescriptor.programState = _programState;
 
-    // setup vertex layout
-    auto vertexLayout = _programState->getVertexLayout();
-    auto attributes   = _programState->getProgram()->getActiveAttributes();
-    auto iter         = attributes.find("a_position");
-    if (iter != attributes.end())
-        vertexLayout->setAttribute("a_position", iter->second.location, backend::VertexFormat::FLOAT2, 0, false);
-
-    iter = attributes.find("a_texCoord");
-    if (iter != attributes.end())
-        vertexLayout->setAttribute("a_texCoord", iter->second.location, backend::VertexFormat::FLOAT2,
-                                   2 * sizeof(float), false);
-
-    vertexLayout->setLayout(4 * sizeof(float));
-
     // create vertex buffer
     _customCommand.setDrawType(CustomCommand::DrawType::ARRAY);
     _customCommand.setPrimitiveType(CustomCommand::PrimitiveType::TRIANGLE_STRIP);

--- a/core/renderer/backend/Program.cpp
+++ b/core/renderer/backend/Program.cpp
@@ -24,10 +24,17 @@
 
 #include "Program.h"
 #include "ProgramCache.h"
+#include "VertexLayout.h"
 
 NS_AX_BACKEND_BEGIN
 
-Program::Program(std::string_view vs, std::string_view fs) : _vertexShader(vs), _fragmentShader(fs) {}
+Program::Program(std::string_view vs, std::string_view fs)
+    : _vertexShader(vs), _fragmentShader(fs), _vertexLayout(new VertexLayout())
+{}
+
+Program::~Program() {
+    delete _vertexLayout;
+}
 
 void Program::setProgramType(uint32_t type)
 {

--- a/core/renderer/backend/Program.h
+++ b/core/renderer/backend/Program.h
@@ -101,7 +101,7 @@ public:
      * Get active vertex attributes.
      * @return Active vertex attributes. key is active attribute name, Value is corresponding attribute info.
      */
-    virtual const hlookup::string_map<AttributeBindInfo> getActiveAttributes() const = 0;
+    virtual const hlookup::string_map<AttributeBindInfo>& getActiveAttributes() const = 0;
 
     /**
      * Get vertex shader.

--- a/core/renderer/backend/Program.h
+++ b/core/renderer/backend/Program.h
@@ -37,6 +37,7 @@
 NS_AX_BACKEND_BEGIN
 
 class ShaderModule;
+class VertexLayout;
 
 /**
  * @addtogroup _backend
@@ -49,6 +50,7 @@ class ShaderModule;
 class AX_DLL Program : public Ref
 {
 public:
+    ~Program();
     /**
      * Get engine built-in program.
      * @param type Specifies the built-in program type.
@@ -146,6 +148,8 @@ public:
      */
     void setProgramType(uint32_t type);
 
+    inline VertexLayout* getVertexLayout() const { return _vertexLayout; }
+
 protected:
     /**
      * @param vs Specifes the vertex shader source.
@@ -185,6 +189,7 @@ protected:
 
     std::string _vertexShader;                            ///< Vertex shader.
     std::string _fragmentShader;                          ///< Fragment shader.
+    VertexLayout* _vertexLayout = nullptr;
     uint32_t _programType = ProgramType::CUSTOM_PROGRAM;  ///< built-in program type, initial value is CUSTOM_PROGRAM.
 };
 

--- a/core/renderer/backend/ProgramCache.cpp
+++ b/core/renderer/backend/ProgramCache.cpp
@@ -79,54 +79,229 @@ ProgramCache::~ProgramCache()
     ShaderCache::destroyInstance();
 }
 
+/*
+ * shader vertex layout setup functions
+ */
+void VertexLayoutHelper::setupForDummy(Program*) {}
+void VertexLayoutHelper::setupForTexture(Program* program) {
+    auto vertexLayout = program->getVertexLayout();
+
+    /// a_position
+    vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_POSITION,
+                               program->getAttributeLocation(backend::Attribute::POSITION),
+                               backend::VertexFormat::FLOAT2, 0, false);
+    /// a_texCoord
+    vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_TEXCOORD,
+                               program->getAttributeLocation(backend::Attribute::TEXCOORD),
+                               backend::VertexFormat::FLOAT2, 2 * sizeof(float), false);
+
+    vertexLayout->setStride(4 * sizeof(float));
+}
+
+void VertexLayoutHelper::setupForSprite(Program* program)
+{
+    auto vertexLayout = program->getVertexLayout();
+
+    /// a_position
+    vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_POSITION,
+                               program->getAttributeLocation(backend::Attribute::POSITION),
+                               backend::VertexFormat::FLOAT3, 0, false);
+    /// a_texCoord
+    vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_TEXCOORD,
+                               program->getAttributeLocation(backend::Attribute::TEXCOORD),
+                               backend::VertexFormat::FLOAT2, offsetof(V3F_C4B_T2F, texCoords), false);
+
+    /// a_color
+    vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_COLOR, program->getAttributeLocation(backend::Attribute::COLOR),
+                               backend::VertexFormat::UBYTE4, offsetof(V3F_C4B_T2F, colors), true);
+    vertexLayout->setStride(sizeof(V3F_C4B_T2F));
+}
+
+void VertexLayoutHelper::setupForDrawNode(Program* program)
+{
+    auto vertexLayout = program->getVertexLayout();
+
+    const auto&& attributeInfo = program->getActiveAttributes();
+    auto iter                  = attributeInfo.find("a_position");
+    if (iter != attributeInfo.end())
+    {
+        vertexLayout->setAttribute("a_position", iter->second.location, backend::VertexFormat::FLOAT2, 0, false);
+    }
+
+    iter = attributeInfo.find("a_texCoord");
+    if (iter != attributeInfo.end())
+    {
+        vertexLayout->setAttribute("a_texCoord", iter->second.location, backend::VertexFormat::FLOAT2,
+                                   offsetof(V2F_C4B_T2F, texCoords), false);
+    }
+
+    iter = attributeInfo.find("a_color");
+    if (iter != attributeInfo.end())
+    {
+        vertexLayout->setAttribute("a_color", iter->second.location, backend::VertexFormat::UBYTE4,
+                                   offsetof(V2F_C4B_T2F, colors), true);
+    }
+    vertexLayout->setStride(sizeof(V2F_C4B_T2F));
+}
+
+void VertexLayoutHelper::setupForDrawNode3D(Program* program)
+{
+    auto vertexLayout = program->getVertexLayout();
+
+    const auto&& attributeInfo = program->getActiveAttributes();
+    auto iter                  = attributeInfo.find("a_position");
+    if (iter != attributeInfo.end())
+    {
+        vertexLayout->setAttribute("a_position", iter->second.location, backend::VertexFormat::FLOAT3, 0, false);
+    }
+    iter = attributeInfo.find("a_color");
+    if (iter != attributeInfo.end())
+    {
+        vertexLayout->setAttribute("a_color", iter->second.location, backend::VertexFormat::UBYTE4, sizeof(Vec3), true);
+    }
+    vertexLayout->setStride(sizeof(V3F_C4B));
+}
+
+void VertexLayoutHelper::setupForSkyBox(Program* program)
+{
+    auto vertexLayout = program->getVertexLayout();
+    auto attrNameLoc  = program->getAttributeLocation(shaderinfos::attribute::ATTRIBUTE_NAME_POSITION);
+    vertexLayout->setAttribute(shaderinfos::attribute::ATTRIBUTE_NAME_POSITION, attrNameLoc,
+                               backend::VertexFormat::FLOAT3, 0, false);
+    vertexLayout->setStride(sizeof(Vec3));
+}
+
+void VertexLayoutHelper::setupForPU3D(Program* program)
+{
+    auto vertexLayout          = program->getVertexLayout();
+    const auto&& attributeInfo = program->getActiveAttributes();
+    auto iter                  = attributeInfo.find("a_position");
+    if (iter != attributeInfo.end())
+    {
+        vertexLayout->setAttribute("a_position", iter->second.location, backend::VertexFormat::FLOAT3,
+                                   offsetof(V3F_T2F_C4F, position), false);
+    }
+    iter = attributeInfo.find("a_texCoord");
+    if (iter != attributeInfo.end())
+    {
+        vertexLayout->setAttribute("a_texCoord", iter->second.location, backend::VertexFormat::FLOAT2,
+                                   offsetof(V3F_T2F_C4F, uv), false);
+    }
+    iter = attributeInfo.find("a_color");
+    if (iter != attributeInfo.end())
+    {
+        vertexLayout->setAttribute("a_color", iter->second.location, backend::VertexFormat::FLOAT4,
+                                   offsetof(V3F_T2F_C4F, color), false);
+    }
+    vertexLayout->setStride(sizeof(V3F_T2F_C4F));
+}
+
+void VertexLayoutHelper::setupForPos(Program* program)
+{
+    auto vertexLayout          = program->getVertexLayout();
+    vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_POSITION,
+                               program->getAttributeLocation(backend::Attribute::POSITION),
+                               backend::VertexFormat::FLOAT2, 0, false);
+    vertexLayout->setStride(sizeof(Vec2));
+}
+
+void VertexLayoutHelper::setupForPosColor(Program* program)
+{
+    auto vertexLayout = program->getVertexLayout();
+    vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_POSITION,
+                               program->getAttributeLocation(backend::Attribute::POSITION),
+                               backend::VertexFormat::FLOAT3, 0, false);
+    vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_COLOR,
+                               program->getAttributeLocation(backend::Attribute::COLOR),
+                               backend::VertexFormat::FLOAT4, offsetof(V3F_C4F, colors), false);
+    vertexLayout->setStride(sizeof(V3F_C4F));
+    
+}
+
+void VertexLayoutHelper::setupForTerrain3D(Program* program) {
+    auto vertexLayout = program->getVertexLayout();
+    vertexLayout->setAttribute("a_position", program->getAttributeLocation(backend::Attribute::POSITION),
+                               backend::VertexFormat::FLOAT3, 0, false);
+    vertexLayout->setAttribute("a_texCoord", program->getAttributeLocation(backend::Attribute::TEXCOORD),
+                               backend::VertexFormat::FLOAT2, offsetof(V3F_T2F_N3F, texcoord), false);
+    vertexLayout->setAttribute("a_normal",program->getAttributeLocation(backend::Attribute::NORMAL), backend::VertexFormat::FLOAT3,
+                                    offsetof(V3F_T2F_N3F, normal), false);
+    vertexLayout->setStride(sizeof(V3F_T2F_N3F));
+}
+
+// ### end of vertex layout setup functions
+
 bool ProgramCache::init()
 {
-    registerProgramFactory(ProgramType::POSITION_TEXTURE_COLOR, positionTextureColor_vert, positionTextureColor_frag);
-    registerProgramFactory(ProgramType::DUAL_SAMPLER, positionTextureColor_vert, dualSampler_frag);
-    registerProgramFactory(ProgramType::LABEL_DISTANCE_NORMAL, positionTextureColor_vert, label_distanceNormal_frag);
-    registerProgramFactory(ProgramType::LABEL_NORMAL, positionTextureColor_vert, label_normal_frag);
-    registerProgramFactory(ProgramType::LABLE_OUTLINE, positionTextureColor_vert, labelOutline_frag);
+    registerProgramFactory(ProgramType::POSITION_TEXTURE_COLOR, positionTextureColor_vert, positionTextureColor_frag,
+                           VertexLayoutHelper::setupForSprite);
+    registerProgramFactory(ProgramType::DUAL_SAMPLER, positionTextureColor_vert, dualSampler_frag,
+                           VertexLayoutHelper::setupForSprite);
+    registerProgramFactory(ProgramType::LABEL_DISTANCE_NORMAL, positionTextureColor_vert, label_distanceNormal_frag,
+                           VertexLayoutHelper::setupForSprite);
+    registerProgramFactory(ProgramType::LABEL_NORMAL, positionTextureColor_vert, label_normal_frag,
+                           VertexLayoutHelper::setupForSprite);
+    registerProgramFactory(ProgramType::LABLE_OUTLINE, positionTextureColor_vert, labelOutline_frag,
+                           VertexLayoutHelper::setupForSprite);
     registerProgramFactory(ProgramType::LABLE_DISTANCEFIELD_GLOW, positionTextureColor_vert,
-                           labelDistanceFieldGlow_frag);
+                           labelDistanceFieldGlow_frag, VertexLayoutHelper::setupForSprite);
     registerProgramFactory(ProgramType::POSITION_COLOR_LENGTH_TEXTURE, positionColorLengthTexture_vert,
-                           positionColorLengthTexture_frag);
+                           positionColorLengthTexture_frag, VertexLayoutHelper::setupForDrawNode);
     registerProgramFactory(ProgramType::POSITION_COLOR_TEXTURE_AS_POINTSIZE, positionColorTextureAsPointsize_vert,
-                           positionColor_frag);
-    registerProgramFactory(ProgramType::POSITION_COLOR, positionColor_vert, positionColor_frag);
-    registerProgramFactory(ProgramType::LAYER_RADIA_GRADIENT, position_vert, layer_radialGradient_frag);
-    registerProgramFactory(ProgramType::POSITION_TEXTURE, positionTexture_vert, positionTexture_frag);
+                           positionColor_frag, VertexLayoutHelper::setupForDrawNode);
+    registerProgramFactory(ProgramType::POSITION_COLOR, positionColor_vert, positionColor_frag,
+                           VertexLayoutHelper::setupForPosColor);
+    registerProgramFactory(ProgramType::LAYER_RADIA_GRADIENT, position_vert, layer_radialGradient_frag,
+                           VertexLayoutHelper::setupForPos);
+    registerProgramFactory(ProgramType::POSITION_TEXTURE, positionTexture_vert, positionTexture_frag,
+                           VertexLayoutHelper::setupForTexture);
     registerProgramFactory(ProgramType::POSITION_TEXTURE_COLOR_ALPHA_TEST, positionTextureColor_vert,
-                           positionTextureColorAlphaTest_frag);
-    registerProgramFactory(ProgramType::POSITION_UCOLOR, positionUColor_vert, positionColor_frag);
-    registerProgramFactory(ProgramType::DUAL_SAMPLER_GRAY, positionTextureColor_vert, dualSampler_gray_frag);
-    registerProgramFactory(ProgramType::GRAY_SCALE, positionTextureColor_vert, grayScale_frag);
-    registerProgramFactory(ProgramType::LINE_COLOR_3D, lineColor3D_vert, lineColor3D_frag);
-    registerProgramFactory(ProgramType::CAMERA_CLEAR, cameraClear_vert, cameraClear_frag);
-    registerProgramFactory(ProgramType::SKYBOX_3D, CC3D_skybox_vert, CC3D_skybox_frag);
-    registerProgramFactory(ProgramType::SKINPOSITION_TEXTURE_3D, CC3D_skinPositionTexture_vert, CC3D_colorTexture_frag);
+                           positionTextureColorAlphaTest_frag, VertexLayoutHelper::setupForSprite);
+    registerProgramFactory(ProgramType::POSITION_UCOLOR, positionUColor_vert, positionColor_frag,
+                           VertexLayoutHelper::setupForPos);
+    registerProgramFactory(ProgramType::DUAL_SAMPLER_GRAY, positionTextureColor_vert, dualSampler_gray_frag,
+                           VertexLayoutHelper::setupForSprite);
+    registerProgramFactory(ProgramType::GRAY_SCALE, positionTextureColor_vert, grayScale_frag,
+                           VertexLayoutHelper::setupForSprite);
+    registerProgramFactory(ProgramType::LINE_COLOR_3D, lineColor3D_vert, lineColor3D_frag,
+                           VertexLayoutHelper::setupForDrawNode3D);
+    registerProgramFactory(ProgramType::CAMERA_CLEAR, cameraClear_vert, cameraClear_frag,
+                           VertexLayoutHelper::setupForSprite);
+    registerProgramFactory(ProgramType::SKYBOX_3D, CC3D_skybox_vert, CC3D_skybox_frag,
+                           VertexLayoutHelper::setupForSkyBox);
+    registerProgramFactory(ProgramType::SKINPOSITION_TEXTURE_3D, CC3D_skinPositionTexture_vert, CC3D_colorTexture_frag,
+                           VertexLayoutHelper::setupForDummy);
     auto lightDef = getShaderMacrosForLight();
     registerProgramFactory(ProgramType::SKINPOSITION_NORMAL_TEXTURE_3D, lightDef + CC3D_skinPositionNormalTexture_vert,
-                           lightDef + CC3D_colorNormalTexture_frag);
+                           lightDef + CC3D_colorNormalTexture_frag, VertexLayoutHelper::setupForDummy);
     registerProgramFactory(ProgramType::POSITION_NORMAL_TEXTURE_3D, lightDef + CC3D_positionNormalTexture_vert,
-                           lightDef + CC3D_colorNormalTexture_frag);
-    registerProgramFactory(ProgramType::POSITION_TEXTURE_3D, CC3D_positionTexture_vert, CC3D_colorTexture_frag);
-    registerProgramFactory(ProgramType::POSITION_3D, CC3D_positionTexture_vert, CC3D_color_frag);
+                           lightDef + CC3D_colorNormalTexture_frag, VertexLayoutHelper::setupForDummy);
+    registerProgramFactory(ProgramType::POSITION_TEXTURE_3D, CC3D_positionTexture_vert, CC3D_colorTexture_frag,
+                           VertexLayoutHelper::setupForDummy);
+    registerProgramFactory(ProgramType::POSITION_3D, CC3D_positionTexture_vert, CC3D_color_frag,
+                           VertexLayoutHelper::setupForSprite);
     registerProgramFactory(ProgramType::POSITION_NORMAL_3D, lightDef + CC3D_positionNormalTexture_vert,
-                           lightDef + CC3D_colorNormal_frag);
+                           lightDef + CC3D_colorNormal_frag, VertexLayoutHelper::setupForDummy);
     const char* normalMapDef = "\n#define USE_NORMAL_MAPPING 1 \n";
     registerProgramFactory(ProgramType::POSITION_BUMPEDNORMAL_TEXTURE_3D,
                            lightDef + normalMapDef + CC3D_positionNormalTexture_vert,
-                           lightDef + normalMapDef + CC3D_colorNormalTexture_frag);
+                           lightDef + normalMapDef + CC3D_colorNormalTexture_frag, VertexLayoutHelper::setupForDummy);
     registerProgramFactory(ProgramType::SKINPOSITION_BUMPEDNORMAL_TEXTURE_3D,
                            lightDef + normalMapDef + CC3D_skinPositionNormalTexture_vert,
-                           lightDef + normalMapDef + CC3D_colorNormalTexture_frag);
-    registerProgramFactory(ProgramType::TERRAIN_3D, CC3D_terrain_vert, CC3D_terrain_frag);
-    registerProgramFactory(ProgramType::PARTICLE_TEXTURE_3D, CC3D_particle_vert, CC3D_particleTexture_frag);
-    registerProgramFactory(ProgramType::PARTICLE_COLOR_3D, CC3D_particle_vert, CC3D_particleColor_frag);
-    registerProgramFactory(ProgramType::QUAD_COLOR_2D, CC2D_quadColor_vert, CC2D_quadColor_frag);
-    registerProgramFactory(ProgramType::QUAD_TEXTURE_2D, CC2D_quadTexture_vert, CC2D_quadTexture_frag);
-    registerProgramFactory(ProgramType::HSV, positionTextureColor_vert, hsv_frag);
-    registerProgramFactory(ProgramType::HSV_DUAL_SAMPLER, positionTextureColor_vert, dualSampler_hsv_frag);
+                           lightDef + normalMapDef + CC3D_colorNormalTexture_frag, VertexLayoutHelper::setupForDummy);
+    registerProgramFactory(ProgramType::TERRAIN_3D, CC3D_terrain_vert, CC3D_terrain_frag,
+                           VertexLayoutHelper::setupForTerrain3D);
+    registerProgramFactory(ProgramType::PARTICLE_TEXTURE_3D, CC3D_particle_vert, CC3D_particleTexture_frag,
+                           VertexLayoutHelper::setupForPU3D);
+    registerProgramFactory(ProgramType::PARTICLE_COLOR_3D, CC3D_particle_vert, CC3D_particleColor_frag,
+                           VertexLayoutHelper::setupForPU3D);
+    registerProgramFactory(ProgramType::QUAD_COLOR_2D, CC2D_quadColor_vert, CC2D_quadColor_frag,
+                           VertexLayoutHelper::setupForDummy);
+    registerProgramFactory(ProgramType::QUAD_TEXTURE_2D, CC2D_quadTexture_vert, CC2D_quadTexture_frag,
+                           VertexLayoutHelper::setupForDummy);
+    registerProgramFactory(ProgramType::HSV, positionTextureColor_vert, hsv_frag, VertexLayoutHelper::setupForSprite);
+    registerProgramFactory(ProgramType::HSV_DUAL_SAMPLER, positionTextureColor_vert, dualSampler_hsv_frag,
+                           VertexLayoutHelper::setupForSprite);
 
     // The builtin dual sampler shader registry
     ProgramStateRegistry::getInstance()->registerProgram(ProgramType::POSITION_TEXTURE_COLOR,
@@ -186,18 +361,24 @@ Program* ProgramCache::addProgram(uint32_t internalType) const
 
 void ProgramCache::registerCustomProgramFactory(uint32_t type,
                                                 std::string vertShaderSource,
-                                                std::string fragShaderSource)
+                                                std::string fragShaderSource,
+                                                std::function<void(Program*)> cbSetupLayout)
 {
     auto internalType = ProgramType::CUSTOM_PROGRAM | type;
-    registerProgramFactory(internalType, std::move(vertShaderSource), std::move(fragShaderSource));
+    registerProgramFactory(internalType, std::move(vertShaderSource), std::move(fragShaderSource),
+                           std::move(cbSetupLayout));
 }
 
 void ProgramCache::registerProgramFactory(uint32_t internalType,
                                           std::string&& vertShaderSource,
-                                          std::string&& fragShaderSource)
+                                          std::string&& fragShaderSource,
+                                          std::function<void(Program*)> cbSetupLayout)
 {
-    auto constructProgram = [vsrc = std::move(vertShaderSource), fsrc = std::move(fragShaderSource)]() {
-        return backend::Device::getInstance()->newProgram(vsrc, fsrc);
+    auto constructProgram = [vsrc = std::move(vertShaderSource), fsrc = std::move(fragShaderSource),
+                             setupLayout = std::move(cbSetupLayout)]() {
+        auto program = backend::Device::getInstance()->newProgram(vsrc, fsrc);
+        setupLayout(program);
+        return program;
     };
 
     if (internalType < ProgramType::BUILTIN_COUNT)

--- a/core/renderer/backend/ProgramCache.cpp
+++ b/core/renderer/backend/ProgramCache.cpp
@@ -1,5 +1,6 @@
 /****************************************************************************
  Copyright (c) 2018-2019 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2022 Bytedance Inc.
 
  https://axys1.github.io/
 
@@ -82,8 +83,9 @@ ProgramCache::~ProgramCache()
 /*
  * shader vertex layout setup functions
  */
-void VertexLayoutHelper::setupForDummy(Program*) {}
-void VertexLayoutHelper::setupForTexture(Program* program) {
+void VertexLayoutHelper::setupDummy(Program*) {}
+void VertexLayoutHelper::setupTexture(Program* program)
+{
     auto vertexLayout = program->getVertexLayout();
 
     /// a_position
@@ -98,7 +100,7 @@ void VertexLayoutHelper::setupForTexture(Program* program) {
     vertexLayout->setStride(4 * sizeof(float));
 }
 
-void VertexLayoutHelper::setupForSprite(Program* program)
+void VertexLayoutHelper::setupSprite(Program* program)
 {
     auto vertexLayout = program->getVertexLayout();
 
@@ -117,52 +119,39 @@ void VertexLayoutHelper::setupForSprite(Program* program)
     vertexLayout->setStride(sizeof(V3F_C4B_T2F));
 }
 
-void VertexLayoutHelper::setupForDrawNode(Program* program)
+void VertexLayoutHelper::setupDrawNode(Program* program)
 {
     auto vertexLayout = program->getVertexLayout();
 
-    const auto&& attributeInfo = program->getActiveAttributes();
-    auto iter                  = attributeInfo.find("a_position");
-    if (iter != attributeInfo.end())
-    {
-        vertexLayout->setAttribute("a_position", iter->second.location, backend::VertexFormat::FLOAT2, 0, false);
-    }
+    vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_POSITION,
+                               program->getAttributeLocation(backend::Attribute::POSITION),
+                               backend::VertexFormat::FLOAT2, 0, false);
 
-    iter = attributeInfo.find("a_texCoord");
-    if (iter != attributeInfo.end())
-    {
-        vertexLayout->setAttribute("a_texCoord", iter->second.location, backend::VertexFormat::FLOAT2,
-                                   offsetof(V2F_C4B_T2F, texCoords), false);
-    }
+    vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_TEXCOORD,
+                               program->getAttributeLocation(backend::Attribute::TEXCOORD),
+                               backend::VertexFormat::FLOAT2, offsetof(V2F_C4B_T2F, texCoords), false);
 
-    iter = attributeInfo.find("a_color");
-    if (iter != attributeInfo.end())
-    {
-        vertexLayout->setAttribute("a_color", iter->second.location, backend::VertexFormat::UBYTE4,
-                                   offsetof(V2F_C4B_T2F, colors), true);
-    }
+    vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_COLOR, program->getAttributeLocation(backend::Attribute::COLOR),
+                               backend::VertexFormat::UBYTE4, offsetof(V2F_C4B_T2F, colors), true);
+
     vertexLayout->setStride(sizeof(V2F_C4B_T2F));
 }
 
-void VertexLayoutHelper::setupForDrawNode3D(Program* program)
+void VertexLayoutHelper::setupDrawNode3D(Program* program)
 {
     auto vertexLayout = program->getVertexLayout();
 
-    const auto&& attributeInfo = program->getActiveAttributes();
-    auto iter                  = attributeInfo.find("a_position");
-    if (iter != attributeInfo.end())
-    {
-        vertexLayout->setAttribute("a_position", iter->second.location, backend::VertexFormat::FLOAT3, 0, false);
-    }
-    iter = attributeInfo.find("a_color");
-    if (iter != attributeInfo.end())
-    {
-        vertexLayout->setAttribute("a_color", iter->second.location, backend::VertexFormat::UBYTE4, sizeof(Vec3), true);
-    }
+    vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_POSITION,
+                               program->getAttributeLocation(backend::Attribute::POSITION),
+                               backend::VertexFormat::FLOAT3, 0, false);
+
+    vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_COLOR, program->getAttributeLocation(backend::Attribute::COLOR),
+                               backend::VertexFormat::UBYTE4, sizeof(Vec3), true);
+
     vertexLayout->setStride(sizeof(V3F_C4B));
 }
 
-void VertexLayoutHelper::setupForSkyBox(Program* program)
+void VertexLayoutHelper::setupSkyBox(Program* program)
 {
     auto vertexLayout = program->getVertexLayout();
     auto attrNameLoc  = program->getAttributeLocation(shaderinfos::attribute::ATTRIBUTE_NAME_POSITION);
@@ -171,61 +160,56 @@ void VertexLayoutHelper::setupForSkyBox(Program* program)
     vertexLayout->setStride(sizeof(Vec3));
 }
 
-void VertexLayoutHelper::setupForPU3D(Program* program)
+void VertexLayoutHelper::setupPU3D(Program* program)
 {
-    auto vertexLayout          = program->getVertexLayout();
-    const auto&& attributeInfo = program->getActiveAttributes();
-    auto iter                  = attributeInfo.find("a_position");
-    if (iter != attributeInfo.end())
-    {
-        vertexLayout->setAttribute("a_position", iter->second.location, backend::VertexFormat::FLOAT3,
-                                   offsetof(V3F_T2F_C4F, position), false);
-    }
-    iter = attributeInfo.find("a_texCoord");
-    if (iter != attributeInfo.end())
-    {
-        vertexLayout->setAttribute("a_texCoord", iter->second.location, backend::VertexFormat::FLOAT2,
-                                   offsetof(V3F_T2F_C4F, uv), false);
-    }
-    iter = attributeInfo.find("a_color");
-    if (iter != attributeInfo.end())
-    {
-        vertexLayout->setAttribute("a_color", iter->second.location, backend::VertexFormat::FLOAT4,
-                                   offsetof(V3F_T2F_C4F, color), false);
-    }
+    auto vertexLayout = program->getVertexLayout();
+
+    vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_POSITION,
+                               program->getAttributeLocation(backend::Attribute::POSITION),
+                               backend::VertexFormat::FLOAT3, offsetof(V3F_T2F_C4F, position), false);
+
+    vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_TEXCOORD,
+                               program->getAttributeLocation(backend::Attribute::TEXCOORD),
+                               backend::VertexFormat::FLOAT2, offsetof(V3F_T2F_C4F, uv), false);
+
+    vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_COLOR, program->getAttributeLocation(backend::Attribute::COLOR),
+                               backend::VertexFormat::FLOAT4, offsetof(V3F_T2F_C4F, color), false);
+
     vertexLayout->setStride(sizeof(V3F_T2F_C4F));
 }
 
-void VertexLayoutHelper::setupForPos(Program* program)
+void VertexLayoutHelper::setupPos(Program* program)
 {
-    auto vertexLayout          = program->getVertexLayout();
+    auto vertexLayout = program->getVertexLayout();
     vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_POSITION,
                                program->getAttributeLocation(backend::Attribute::POSITION),
                                backend::VertexFormat::FLOAT2, 0, false);
     vertexLayout->setStride(sizeof(Vec2));
 }
 
-void VertexLayoutHelper::setupForPosColor(Program* program)
+void VertexLayoutHelper::setupPosColor(Program* program)
 {
     auto vertexLayout = program->getVertexLayout();
     vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_POSITION,
                                program->getAttributeLocation(backend::Attribute::POSITION),
                                backend::VertexFormat::FLOAT3, 0, false);
-    vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_COLOR,
-                               program->getAttributeLocation(backend::Attribute::COLOR),
+    vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_COLOR, program->getAttributeLocation(backend::Attribute::COLOR),
                                backend::VertexFormat::FLOAT4, offsetof(V3F_C4F, colors), false);
     vertexLayout->setStride(sizeof(V3F_C4F));
-    
 }
 
-void VertexLayoutHelper::setupForTerrain3D(Program* program) {
+void VertexLayoutHelper::setupTerrain3D(Program* program)
+{
     auto vertexLayout = program->getVertexLayout();
-    vertexLayout->setAttribute("a_position", program->getAttributeLocation(backend::Attribute::POSITION),
+    vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_POSITION,
+                               program->getAttributeLocation(backend::Attribute::POSITION),
                                backend::VertexFormat::FLOAT3, 0, false);
-    vertexLayout->setAttribute("a_texCoord", program->getAttributeLocation(backend::Attribute::TEXCOORD),
+    vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_TEXCOORD,
+                               program->getAttributeLocation(backend::Attribute::TEXCOORD),
                                backend::VertexFormat::FLOAT2, offsetof(V3F_T2F_N3F, texcoord), false);
-    vertexLayout->setAttribute("a_normal",program->getAttributeLocation(backend::Attribute::NORMAL), backend::VertexFormat::FLOAT3,
-                                    offsetof(V3F_T2F_N3F, normal), false);
+    vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_NORMAL,
+                               program->getAttributeLocation(backend::Attribute::NORMAL), backend::VertexFormat::FLOAT3,
+                               offsetof(V3F_T2F_N3F, normal), false);
     vertexLayout->setStride(sizeof(V3F_T2F_N3F));
 }
 
@@ -234,74 +218,73 @@ void VertexLayoutHelper::setupForTerrain3D(Program* program) {
 bool ProgramCache::init()
 {
     registerProgramFactory(ProgramType::POSITION_TEXTURE_COLOR, positionTextureColor_vert, positionTextureColor_frag,
-                           VertexLayoutHelper::setupForSprite);
+                           VertexLayoutHelper::setupSprite);
     registerProgramFactory(ProgramType::DUAL_SAMPLER, positionTextureColor_vert, dualSampler_frag,
-                           VertexLayoutHelper::setupForSprite);
+                           VertexLayoutHelper::setupSprite);
     registerProgramFactory(ProgramType::LABEL_DISTANCE_NORMAL, positionTextureColor_vert, label_distanceNormal_frag,
-                           VertexLayoutHelper::setupForSprite);
+                           VertexLayoutHelper::setupSprite);
     registerProgramFactory(ProgramType::LABEL_NORMAL, positionTextureColor_vert, label_normal_frag,
-                           VertexLayoutHelper::setupForSprite);
+                           VertexLayoutHelper::setupSprite);
     registerProgramFactory(ProgramType::LABLE_OUTLINE, positionTextureColor_vert, labelOutline_frag,
-                           VertexLayoutHelper::setupForSprite);
+                           VertexLayoutHelper::setupSprite);
     registerProgramFactory(ProgramType::LABLE_DISTANCEFIELD_GLOW, positionTextureColor_vert,
-                           labelDistanceFieldGlow_frag, VertexLayoutHelper::setupForSprite);
+                           labelDistanceFieldGlow_frag, VertexLayoutHelper::setupSprite);
     registerProgramFactory(ProgramType::POSITION_COLOR_LENGTH_TEXTURE, positionColorLengthTexture_vert,
-                           positionColorLengthTexture_frag, VertexLayoutHelper::setupForDrawNode);
+                           positionColorLengthTexture_frag, VertexLayoutHelper::setupDrawNode);
     registerProgramFactory(ProgramType::POSITION_COLOR_TEXTURE_AS_POINTSIZE, positionColorTextureAsPointsize_vert,
-                           positionColor_frag, VertexLayoutHelper::setupForDrawNode);
+                           positionColor_frag, VertexLayoutHelper::setupDrawNode);
     registerProgramFactory(ProgramType::POSITION_COLOR, positionColor_vert, positionColor_frag,
-                           VertexLayoutHelper::setupForPosColor);
+                           VertexLayoutHelper::setupPosColor);
     registerProgramFactory(ProgramType::LAYER_RADIA_GRADIENT, position_vert, layer_radialGradient_frag,
-                           VertexLayoutHelper::setupForPos);
+                           VertexLayoutHelper::setupPos);
     registerProgramFactory(ProgramType::POSITION_TEXTURE, positionTexture_vert, positionTexture_frag,
-                           VertexLayoutHelper::setupForTexture);
+                           VertexLayoutHelper::setupTexture);
     registerProgramFactory(ProgramType::POSITION_TEXTURE_COLOR_ALPHA_TEST, positionTextureColor_vert,
-                           positionTextureColorAlphaTest_frag, VertexLayoutHelper::setupForSprite);
+                           positionTextureColorAlphaTest_frag, VertexLayoutHelper::setupSprite);
     registerProgramFactory(ProgramType::POSITION_UCOLOR, positionUColor_vert, positionColor_frag,
-                           VertexLayoutHelper::setupForPos);
+                           VertexLayoutHelper::setupPos);
     registerProgramFactory(ProgramType::DUAL_SAMPLER_GRAY, positionTextureColor_vert, dualSampler_gray_frag,
-                           VertexLayoutHelper::setupForSprite);
+                           VertexLayoutHelper::setupSprite);
     registerProgramFactory(ProgramType::GRAY_SCALE, positionTextureColor_vert, grayScale_frag,
-                           VertexLayoutHelper::setupForSprite);
+                           VertexLayoutHelper::setupSprite);
     registerProgramFactory(ProgramType::LINE_COLOR_3D, lineColor3D_vert, lineColor3D_frag,
-                           VertexLayoutHelper::setupForDrawNode3D);
+                           VertexLayoutHelper::setupDrawNode3D);
     registerProgramFactory(ProgramType::CAMERA_CLEAR, cameraClear_vert, cameraClear_frag,
-                           VertexLayoutHelper::setupForSprite);
-    registerProgramFactory(ProgramType::SKYBOX_3D, CC3D_skybox_vert, CC3D_skybox_frag,
-                           VertexLayoutHelper::setupForSkyBox);
+                           VertexLayoutHelper::setupSprite);
+    registerProgramFactory(ProgramType::SKYBOX_3D, CC3D_skybox_vert, CC3D_skybox_frag, VertexLayoutHelper::setupSkyBox);
     registerProgramFactory(ProgramType::SKINPOSITION_TEXTURE_3D, CC3D_skinPositionTexture_vert, CC3D_colorTexture_frag,
-                           VertexLayoutHelper::setupForDummy);
+                           VertexLayoutHelper::setupDummy);
     auto lightDef = getShaderMacrosForLight();
     registerProgramFactory(ProgramType::SKINPOSITION_NORMAL_TEXTURE_3D, lightDef + CC3D_skinPositionNormalTexture_vert,
-                           lightDef + CC3D_colorNormalTexture_frag, VertexLayoutHelper::setupForDummy);
+                           lightDef + CC3D_colorNormalTexture_frag, VertexLayoutHelper::setupDummy);
     registerProgramFactory(ProgramType::POSITION_NORMAL_TEXTURE_3D, lightDef + CC3D_positionNormalTexture_vert,
-                           lightDef + CC3D_colorNormalTexture_frag, VertexLayoutHelper::setupForDummy);
+                           lightDef + CC3D_colorNormalTexture_frag, VertexLayoutHelper::setupDummy);
     registerProgramFactory(ProgramType::POSITION_TEXTURE_3D, CC3D_positionTexture_vert, CC3D_colorTexture_frag,
-                           VertexLayoutHelper::setupForDummy);
+                           VertexLayoutHelper::setupDummy);
     registerProgramFactory(ProgramType::POSITION_3D, CC3D_positionTexture_vert, CC3D_color_frag,
-                           VertexLayoutHelper::setupForSprite);
+                           VertexLayoutHelper::setupSprite);
     registerProgramFactory(ProgramType::POSITION_NORMAL_3D, lightDef + CC3D_positionNormalTexture_vert,
-                           lightDef + CC3D_colorNormal_frag, VertexLayoutHelper::setupForDummy);
+                           lightDef + CC3D_colorNormal_frag, VertexLayoutHelper::setupDummy);
     const char* normalMapDef = "\n#define USE_NORMAL_MAPPING 1 \n";
     registerProgramFactory(ProgramType::POSITION_BUMPEDNORMAL_TEXTURE_3D,
                            lightDef + normalMapDef + CC3D_positionNormalTexture_vert,
-                           lightDef + normalMapDef + CC3D_colorNormalTexture_frag, VertexLayoutHelper::setupForDummy);
+                           lightDef + normalMapDef + CC3D_colorNormalTexture_frag, VertexLayoutHelper::setupDummy);
     registerProgramFactory(ProgramType::SKINPOSITION_BUMPEDNORMAL_TEXTURE_3D,
                            lightDef + normalMapDef + CC3D_skinPositionNormalTexture_vert,
-                           lightDef + normalMapDef + CC3D_colorNormalTexture_frag, VertexLayoutHelper::setupForDummy);
+                           lightDef + normalMapDef + CC3D_colorNormalTexture_frag, VertexLayoutHelper::setupDummy);
     registerProgramFactory(ProgramType::TERRAIN_3D, CC3D_terrain_vert, CC3D_terrain_frag,
-                           VertexLayoutHelper::setupForTerrain3D);
+                           VertexLayoutHelper::setupTerrain3D);
     registerProgramFactory(ProgramType::PARTICLE_TEXTURE_3D, CC3D_particle_vert, CC3D_particleTexture_frag,
-                           VertexLayoutHelper::setupForPU3D);
+                           VertexLayoutHelper::setupPU3D);
     registerProgramFactory(ProgramType::PARTICLE_COLOR_3D, CC3D_particle_vert, CC3D_particleColor_frag,
-                           VertexLayoutHelper::setupForPU3D);
+                           VertexLayoutHelper::setupPU3D);
     registerProgramFactory(ProgramType::QUAD_COLOR_2D, CC2D_quadColor_vert, CC2D_quadColor_frag,
-                           VertexLayoutHelper::setupForDummy);
+                           VertexLayoutHelper::setupDummy);
     registerProgramFactory(ProgramType::QUAD_TEXTURE_2D, CC2D_quadTexture_vert, CC2D_quadTexture_frag,
-                           VertexLayoutHelper::setupForDummy);
-    registerProgramFactory(ProgramType::HSV, positionTextureColor_vert, hsv_frag, VertexLayoutHelper::setupForSprite);
+                           VertexLayoutHelper::setupDummy);
+    registerProgramFactory(ProgramType::HSV, positionTextureColor_vert, hsv_frag, VertexLayoutHelper::setupSprite);
     registerProgramFactory(ProgramType::HSV_DUAL_SAMPLER, positionTextureColor_vert, dualSampler_hsv_frag,
-                           VertexLayoutHelper::setupForSprite);
+                           VertexLayoutHelper::setupSprite);
 
     // The builtin dual sampler shader registry
     ProgramStateRegistry::getInstance()->registerProgram(ProgramType::POSITION_TEXTURE_COLOR,
@@ -362,20 +345,20 @@ Program* ProgramCache::addProgram(uint32_t internalType) const
 void ProgramCache::registerCustomProgramFactory(uint32_t type,
                                                 std::string vertShaderSource,
                                                 std::string fragShaderSource,
-                                                std::function<void(Program*)> cbSetupLayout)
+                                                std::function<void(Program*)> fnSetupLayout)
 {
     auto internalType = ProgramType::CUSTOM_PROGRAM | type;
     registerProgramFactory(internalType, std::move(vertShaderSource), std::move(fragShaderSource),
-                           std::move(cbSetupLayout));
+                           std::move(fnSetupLayout));
 }
 
 void ProgramCache::registerProgramFactory(uint32_t internalType,
                                           std::string&& vertShaderSource,
                                           std::string&& fragShaderSource,
-                                          std::function<void(Program*)> cbSetupLayout)
+                                          std::function<void(Program*)> fnSetupLayout)
 {
     auto constructProgram = [vsrc = std::move(vertShaderSource), fsrc = std::move(fragShaderSource),
-                             setupLayout = std::move(cbSetupLayout)]() {
+                             setupLayout = std::move(fnSetupLayout)]() {
         auto program = backend::Device::getInstance()->newProgram(vsrc, fsrc);
         setupLayout(program);
         return program;

--- a/core/renderer/backend/ProgramCache.h
+++ b/core/renderer/backend/ProgramCache.h
@@ -40,6 +40,20 @@ NS_AX_BACKEND_BEGIN
  * @{
  */
 
+struct AX_DLL VertexLayoutHelper
+{
+    static void setupForDummy(Program*);
+    static void setupForPos(Program*);
+    static void setupForTexture(Program*);
+    static void setupForSprite(Program*);
+    static void setupForDrawNode(Program*);
+    static void setupForDrawNode3D(Program*);
+    static void setupForSkyBox(Program*);
+    static void setupForPU3D(Program*);
+    static void setupForPosColor(Program*);
+    static void setupForTerrain3D(Program*);
+};
+
 /**
  * Cache and reuse program object.
  */
@@ -59,7 +73,10 @@ public:
     backend::Program* getCustomProgram(uint32_t type) const;
 
     // register custom program create factory
-    void registerCustomProgramFactory(uint32_t type, std::string vertShaderSource, std::string fragShaderSource);
+    void registerCustomProgramFactory(uint32_t type,
+                                      std::string vertShaderSource,
+                                      std::string fragShaderSource,
+                                      std::function<void(Program*)> cbSetupLayout = VertexLayoutHelper::setupForDummy);
 
     /**
      * Remove a program object from cache.
@@ -86,7 +103,10 @@ protected:
      */
     bool init();
 
-    void registerProgramFactory(uint32_t internalType, std::string&& vertShaderSource, std::string&& fragShaderSource);
+    void registerProgramFactory(uint32_t internalType,
+                                std::string&& vertShaderSource,
+                                std::string&& fragShaderSource,
+                                std::function<void(Program*)> cbSetupLayout);
     Program* addProgram(uint32_t internalType) const;
 
     std::function<Program*()> _builtinFactories[(int)ProgramType::BUILTIN_COUNT];

--- a/core/renderer/backend/ProgramCache.h
+++ b/core/renderer/backend/ProgramCache.h
@@ -1,5 +1,6 @@
 /****************************************************************************
  Copyright (c) 2018-2019 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2022 Bytedance Inc.
 
  https://axys1.github.io/
 
@@ -42,16 +43,16 @@ NS_AX_BACKEND_BEGIN
 
 struct AX_DLL VertexLayoutHelper
 {
-    static void setupForDummy(Program*);
-    static void setupForPos(Program*);
-    static void setupForTexture(Program*);
-    static void setupForSprite(Program*);
-    static void setupForDrawNode(Program*);
-    static void setupForDrawNode3D(Program*);
-    static void setupForSkyBox(Program*);
-    static void setupForPU3D(Program*);
-    static void setupForPosColor(Program*);
-    static void setupForTerrain3D(Program*);
+    static void setupDummy(Program*);
+    static void setupPos(Program*);
+    static void setupTexture(Program*);
+    static void setupSprite(Program*);
+    static void setupDrawNode(Program*);
+    static void setupDrawNode3D(Program*);
+    static void setupSkyBox(Program*);
+    static void setupPU3D(Program*);
+    static void setupPosColor(Program*);
+    static void setupTerrain3D(Program*);
 };
 
 /**
@@ -76,7 +77,7 @@ public:
     void registerCustomProgramFactory(uint32_t type,
                                       std::string vertShaderSource,
                                       std::string fragShaderSource,
-                                      std::function<void(Program*)> cbSetupLayout = VertexLayoutHelper::setupForDummy);
+                                      std::function<void(Program*)> fnSetupLayout = VertexLayoutHelper::setupDummy);
 
     /**
      * Remove a program object from cache.
@@ -106,7 +107,7 @@ protected:
     void registerProgramFactory(uint32_t internalType,
                                 std::string&& vertShaderSource,
                                 std::string&& fragShaderSource,
-                                std::function<void(Program*)> cbSetupLayout);
+                                std::function<void(Program*)> fnSetupLayout);
     Program* addProgram(uint32_t internalType) const;
 
     std::function<Program*()> _builtinFactories[(int)ProgramType::BUILTIN_COUNT];

--- a/core/renderer/backend/ProgramState.cpp
+++ b/core/renderer/backend/ProgramState.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
  Copyright (c) 2018-2019 Xiamen Yaji Software Co., Ltd.
- Copyright (c) 2021 Bytedance Inc.
+ Copyright (c) 2021-2022 Bytedance Inc.
 
  https://axys1.github.io/
 

--- a/core/renderer/backend/ProgramState.cpp
+++ b/core/renderer/backend/ProgramState.cpp
@@ -246,7 +246,7 @@ ProgramState::~ProgramState()
 #endif
 
     if (_ownVertexLayout)
-        CC_SAFE_DELETE(_vertexLayout);
+        AX_SAFE_DELETE(_vertexLayout);
 }
 
 ProgramState* ProgramState::clone() const

--- a/core/renderer/backend/ProgramState.cpp
+++ b/core/renderer/backend/ProgramState.cpp
@@ -191,6 +191,8 @@ bool ProgramState::init(Program* program)
 {
     AX_SAFE_RETAIN(program);
     _program                 = program;
+    _vertexLayout            = program->getVertexLayout();
+    _ownVertexLayout         = false;
     _vertexUniformBufferSize = _program->getUniformBufferSize(ShaderStage::VERTEX);
     _vertexUniformBuffer     = (char*)calloc(1, _vertexUniformBufferSize);
 #ifdef AX_USE_METAL
@@ -242,6 +244,9 @@ ProgramState::~ProgramState()
 #if AX_ENABLE_CACHE_TEXTURE_DATA
     Director::getInstance()->getEventDispatcher()->removeEventListener(_backToForegroundListener);
 #endif
+
+    if (_ownVertexLayout)
+        CC_SAFE_DELETE(_vertexLayout);
 }
 
 ProgramState* ProgramState::clone() const
@@ -250,7 +255,9 @@ ProgramState* ProgramState::clone() const
     cp->_vertexTextureInfos   = _vertexTextureInfos;
     cp->_fragmentTextureInfos = _fragmentTextureInfos;
     memcpy(cp->_vertexUniformBuffer, _vertexUniformBuffer, _vertexUniformBufferSize);
-    cp->_vertexLayout = _vertexLayout;
+
+    cp->_ownVertexLayout = _ownVertexLayout;
+    cp->_vertexLayout    = !_ownVertexLayout ? _vertexLayout : new VertexLayout(*_vertexLayout);
 #ifdef AX_USE_METAL
     memcpy(cp->_fragmentUniformBuffer, _fragmentUniformBuffer, _fragmentUniformBufferSize);
 #endif
@@ -402,6 +409,37 @@ void ProgramState::setFragmentUniform(int location, const void* data, std::size_
         memcpy(_fragmentUniformBuffer + location, data, size);
     }
 #endif
+}
+
+void ProgramState::setVertexAttrib(std::string_view name,
+    std::size_t index,
+    VertexFormat format,
+    std::size_t offset,
+    bool needToBeNormallized)
+{
+    ensureVertexLayoutMutable();
+
+    _vertexLayout->setAttribute(name, index, format, offset, needToBeNormallized);
+}
+
+void ProgramState::setVertexStride(uint32_t stride)
+{
+    ensureVertexLayoutMutable();
+    _vertexLayout->setStride(stride);
+}
+
+void ProgramState::setVertexLayout(const VertexLayout& vertexLayout) {
+    ensureVertexLayoutMutable();
+    *_vertexLayout = vertexLayout;
+}
+
+void ProgramState::ensureVertexLayoutMutable()
+{
+    if (!_ownVertexLayout)
+    {
+        _vertexLayout = new VertexLayout();
+        _ownVertexLayout = true;
+    }
 }
 
 void ProgramState::updateUniformID(int uniformID)

--- a/core/renderer/backend/ProgramState.h
+++ b/core/renderer/backend/ProgramState.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  Copyright (c) 2018-2019 Xiamen Yaji Software Co., Ltd.
- Copyright (c) 2021 Bytedance Inc.
+ Copyright (c) 2021-2022 Bytedance Inc.
 
  https://axys1.github.io/
 

--- a/core/renderer/backend/ProgramState.h
+++ b/core/renderer/backend/ProgramState.h
@@ -292,7 +292,7 @@ public:
      */
     void setParameterAutoBinding(std::string_view uniformName, std::string_view autoBinding);
 
-    inline std::shared_ptr<VertexLayout> getVertexLayout() const { return _vertexLayout; }
+    inline const VertexLayout* getVertexLayout() const { return _vertexLayout; }
 
     /**
      * Gets uniformID, it's part of materialID for batch draw
@@ -308,7 +308,19 @@ public:
      */
     void updateUniformID(int uniformID = -1);
 
+    void setVertexAttrib(std::string_view name,
+                         std::size_t index,
+                         VertexFormat format,
+                         std::size_t offset,
+                         bool needToBeNormallized);
+    void setVertexStride(uint32_t stride);
+
+    void setVertexLayout(const VertexLayout& vertexLayout);
+
 protected:
+
+    void ensureVertexLayoutMutable();
+
     /**
      * Set the vertex uniform data.
      * @param location Specifies the uniform location.
@@ -392,7 +404,8 @@ protected:
     std::unordered_map<std::string, std::string> _autoBindings;
 
     static std::vector<AutoBindingResolver*> _customAutoBindingResolvers;
-    std::shared_ptr<VertexLayout> _vertexLayout = std::make_shared<VertexLayout>();
+    VertexLayout* _vertexLayout = nullptr;
+    bool _ownVertexLayout = false;
 
     uint32_t _uniformID = 0;
 #ifdef AX_USE_METAL

--- a/core/renderer/backend/ShaderModule.h
+++ b/core/renderer/backend/ShaderModule.h
@@ -57,6 +57,7 @@ enum Attribute : uint32_t
     TEXCOORD1,
     TEXCOORD2,
     TEXCOORD3,
+    NORMAL,
     ATTRIBUTE_MAX  // Maximum attributes
 };
 /**

--- a/core/renderer/backend/Types.h
+++ b/core/renderer/backend/Types.h
@@ -125,6 +125,7 @@ static const char* ATTRIBUTE_NAME_TEXCOORD  = "a_texCoord";
 static const char* ATTRIBUTE_NAME_TEXCOORD1 = "a_texCoord1";
 static const char* ATTRIBUTE_NAME_TEXCOORD2 = "a_texCoord2";
 static const char* ATTRIBUTE_NAME_TEXCOORD3 = "a_texCoord3";
+static const char* ATTRIBUTE_NAME_NORMAL    = "a_normal";
 
 /**
  * @brief a structor to store blend descriptor

--- a/core/renderer/backend/Types.h
+++ b/core/renderer/backend/Types.h
@@ -34,6 +34,8 @@
 
 #include "Enums.h"
 
+using namespace std::string_view_literals;
+
 NS_AX_BACKEND_BEGIN
 
 inline TargetBufferFlags getMRTColorFlag(size_t index) noexcept
@@ -109,23 +111,23 @@ struct AttributeBindInfo
 };
 
 /// built-in uniform name
-static const char* UNIFORM_NAME_MVP_MATRIX   = "u_MVPMatrix";
-static const char* UNIFORM_NAME_TEXTURE      = "u_tex0";
-static const char* UNIFORM_NAME_TEXTURE1     = "u_tex1";
-static const char* UNIFORM_NAME_TEXTURE2     = "u_tex2";
-static const char* UNIFORM_NAME_TEXTURE3     = "u_tex3";
-static const char* UNIFORM_NAME_TEXT_COLOR   = "u_textColor";
-static const char* UNIFORM_NAME_EFFECT_COLOR = "u_effectColor";
-static const char* UNIFORM_NAME_EFFECT_TYPE  = "u_effectType";
+static constexpr auto UNIFORM_NAME_MVP_MATRIX   = "u_MVPMatrix"sv;
+static constexpr auto UNIFORM_NAME_TEXTURE      = "u_tex0"sv;
+static constexpr auto UNIFORM_NAME_TEXTURE1     = "u_tex1"sv;
+static constexpr auto UNIFORM_NAME_TEXTURE2     = "u_tex2"sv;
+static constexpr auto UNIFORM_NAME_TEXTURE3     = "u_tex3"sv;
+static constexpr auto UNIFORM_NAME_TEXT_COLOR   = "u_textColor"sv;
+static constexpr auto UNIFORM_NAME_EFFECT_COLOR = "u_effectColor"sv;
+static constexpr auto UNIFORM_NAME_EFFECT_TYPE  = "u_effectType"sv;
 
 /// built-in attribute name
-static const char* ATTRIBUTE_NAME_POSITION  = "a_position";
-static const char* ATTRIBUTE_NAME_COLOR     = "a_color";
-static const char* ATTRIBUTE_NAME_TEXCOORD  = "a_texCoord";
-static const char* ATTRIBUTE_NAME_TEXCOORD1 = "a_texCoord1";
-static const char* ATTRIBUTE_NAME_TEXCOORD2 = "a_texCoord2";
-static const char* ATTRIBUTE_NAME_TEXCOORD3 = "a_texCoord3";
-static const char* ATTRIBUTE_NAME_NORMAL    = "a_normal";
+static constexpr auto ATTRIBUTE_NAME_POSITION  = "a_position"sv;
+static constexpr auto ATTRIBUTE_NAME_COLOR     = "a_color"sv;
+static constexpr auto ATTRIBUTE_NAME_TEXCOORD  = "a_texCoord"sv;
+static constexpr auto ATTRIBUTE_NAME_TEXCOORD1 = "a_texCoord1"sv;
+static constexpr auto ATTRIBUTE_NAME_TEXCOORD2 = "a_texCoord2"sv;
+static constexpr auto ATTRIBUTE_NAME_TEXCOORD3 = "a_texCoord3"sv;
+static constexpr auto ATTRIBUTE_NAME_NORMAL    = "a_normal"sv;
 
 /**
  * @brief a structor to store blend descriptor

--- a/core/renderer/backend/VertexLayout.cpp
+++ b/core/renderer/backend/VertexLayout.cpp
@@ -44,7 +44,7 @@ void VertexLayout::setAttribute(std::string_view name,
                   needToBeNormallized});  // _attributes[name] = {name, index, format, offset, needToBeNormallized};
 }
 
-void VertexLayout::setLayout(std::size_t stride)
+void VertexLayout::setStride(std::size_t stride)
 {
     _stride = stride;
 }

--- a/core/renderer/backend/VertexLayout.h
+++ b/core/renderer/backend/VertexLayout.h
@@ -64,6 +64,7 @@ public:
     };
 
     VertexLayout() = default;
+    VertexLayout(const VertexLayout&) = default;
 
     /**
      * Set attribute values to name.
@@ -84,7 +85,7 @@ public:
      * Set stride of vertices.
      * @param stride Specifies the distance between the data of two vertices, in bytes.
      */
-    void setLayout(std::size_t stride);
+    void setStride(std::size_t stride);
 
     /**
      * Get the distance between the data of two vertices, in bytes.

--- a/core/renderer/backend/metal/ProgramMTL.h
+++ b/core/renderer/backend/metal/ProgramMTL.h
@@ -94,7 +94,7 @@ public:
      * Get active vertex attributes.
      * @return Active vertex attributes. key is active attribute name, Value is corresponding attribute info.
      */
-    const hlookup::string_map<AttributeBindInfo> getActiveAttributes() const override;
+    const hlookup::string_map<AttributeBindInfo>& getActiveAttributes() const override;
 
     /**
      * Get maximum vertex location.

--- a/core/renderer/backend/metal/ProgramMTL.mm
+++ b/core/renderer/backend/metal/ProgramMTL.mm
@@ -118,7 +118,7 @@ int ProgramMTL::getMaxFragmentLocation() const
     return _fragmentShader->getMaxLocation();
 }
 
-const hlookup::string_map<AttributeBindInfo> ProgramMTL::getActiveAttributes() const
+const hlookup::string_map<AttributeBindInfo>& ProgramMTL::getActiveAttributes() const
 {
     return _vertexShader->getAttributeInfo();
 }

--- a/core/renderer/backend/metal/ShaderModuleMTL.h
+++ b/core/renderer/backend/metal/ShaderModuleMTL.h
@@ -83,7 +83,7 @@ public:
      * Get active attribute informations.
      * @return Active attribute informations. key is attribute name and Value is corresponding attribute info.
      */
-    inline const hlookup::string_map<AttributeBindInfo> getAttributeInfo() const { return _attributeInfo; }
+    inline const hlookup::string_map<AttributeBindInfo>& getAttributeInfo() const { return _attributeInfo; }
 
     /**
      * Get uniform location by engine built-in uniform enum name.

--- a/core/renderer/backend/metal/ShaderModuleMTL.mm
+++ b/core/renderer/backend/metal/ShaderModuleMTL.mm
@@ -254,6 +254,13 @@ void ShaderModuleMTL::setBuiltinAttributeLocation()
     {
         _attributeLocation[Attribute::TEXCOORD] = iter->second.location;
     }
+
+    /// a_normal
+    iter = _attributeInfo.find(ATTRIBUTE_NAME_NORMAL);
+    if (iter != _attributeInfo.end())
+    {
+        _attributeLocation[Attribute::NORMAL] = iter->second.location;
+    }
 }
 
 void ShaderModuleMTL::parseTexture(id<MTLDevice> mtlDevice, glslopt_shader* shader)

--- a/core/renderer/backend/opengl/ProgramGL.cpp
+++ b/core/renderer/backend/opengl/ProgramGL.cpp
@@ -155,51 +155,51 @@ void ProgramGL::computeLocations()
     //    std::fill(_builtinUniformLocation, _builtinUniformLocation + UNIFORM_MAX, -1);
 
     /// a_position
-    auto location                                  = glGetAttribLocation(_program, ATTRIBUTE_NAME_POSITION);
+    auto location                                  = glGetAttribLocation(_program, ATTRIBUTE_NAME_POSITION.data());
     _builtinAttributeLocation[Attribute::POSITION] = location;
 
     /// a_color
-    location                                    = glGetAttribLocation(_program, ATTRIBUTE_NAME_COLOR);
+    location                                    = glGetAttribLocation(_program, ATTRIBUTE_NAME_COLOR.data());
     _builtinAttributeLocation[Attribute::COLOR] = location;
 
     /// a_texCoord
-    location                                       = glGetAttribLocation(_program, ATTRIBUTE_NAME_TEXCOORD);
+    location                                       = glGetAttribLocation(_program, ATTRIBUTE_NAME_TEXCOORD.data());
     _builtinAttributeLocation[Attribute::TEXCOORD] = location;
 
     // a_normal
-    location                                     = glGetAttribLocation(_program, ATTRIBUTE_NAME_NORMAL);
+    location                                     = glGetAttribLocation(_program, ATTRIBUTE_NAME_NORMAL.data());
     _builtinAttributeLocation[Attribute::NORMAL] = location;
 
     /// u_MVPMatrix
-    location                                                 = glGetUniformLocation(_program, UNIFORM_NAME_MVP_MATRIX);
+    location = glGetUniformLocation(_program, UNIFORM_NAME_MVP_MATRIX.data());
     _builtinUniformLocation[Uniform::MVP_MATRIX].location[0] = location;
     _builtinUniformLocation[Uniform::MVP_MATRIX].location[1] =
         _activeUniformInfos[UNIFORM_NAME_MVP_MATRIX].bufferOffset;
 
     /// u_textColor
-    location                                                 = glGetUniformLocation(_program, UNIFORM_NAME_TEXT_COLOR);
+    location = glGetUniformLocation(_program, UNIFORM_NAME_TEXT_COLOR.data());
     _builtinUniformLocation[Uniform::TEXT_COLOR].location[0] = location;
     _builtinUniformLocation[Uniform::TEXT_COLOR].location[1] =
         _activeUniformInfos[UNIFORM_NAME_TEXT_COLOR].bufferOffset;
 
     /// u_effectColor
-    location = glGetUniformLocation(_program, UNIFORM_NAME_EFFECT_COLOR);
+    location = glGetUniformLocation(_program, UNIFORM_NAME_EFFECT_COLOR.data());
     _builtinUniformLocation[Uniform::EFFECT_COLOR].location[0] = location;
     _builtinUniformLocation[Uniform::EFFECT_COLOR].location[1] =
         _activeUniformInfos[UNIFORM_NAME_EFFECT_COLOR].bufferOffset;
 
     /// u_effectType
-    location = glGetUniformLocation(_program, UNIFORM_NAME_EFFECT_TYPE);
+    location = glGetUniformLocation(_program, UNIFORM_NAME_EFFECT_TYPE.data());
     _builtinUniformLocation[Uniform::EFFECT_TYPE].location[0] = location;
     _builtinUniformLocation[Uniform::EFFECT_TYPE].location[1] =
         _activeUniformInfos[UNIFORM_NAME_EFFECT_TYPE].bufferOffset;
 
     /// u_tex0
-    location                                              = glGetUniformLocation(_program, UNIFORM_NAME_TEXTURE);
+    location                                              = glGetUniformLocation(_program, UNIFORM_NAME_TEXTURE.data());
     _builtinUniformLocation[Uniform::TEXTURE].location[0] = location;
 
     /// u_tex1
-    location                                               = glGetUniformLocation(_program, UNIFORM_NAME_TEXTURE1);
+    location = glGetUniformLocation(_program, UNIFORM_NAME_TEXTURE1.data());
     _builtinUniformLocation[Uniform::TEXTURE1].location[0] = location;
 }
 

--- a/core/renderer/backend/opengl/ProgramGL.cpp
+++ b/core/renderer/backend/opengl/ProgramGL.cpp
@@ -72,6 +72,7 @@ ProgramGL::ProgramGL(std::string_view vertexShader, std::string_view fragmentSha
         EventListenerCustom::create(EVENT_RENDERER_RECREATED, [this](EventCustom*) { this->reloadProgram(); });
     Director::getInstance()->getEventDispatcher()->addEventListenerWithFixedPriority(_backToForegroundListener, -1);
 #endif
+    setupVertexLayout();
 }
 
 ProgramGL::~ProgramGL()
@@ -165,6 +166,10 @@ void ProgramGL::computeLocations()
     location                                       = glGetAttribLocation(_program, ATTRIBUTE_NAME_TEXCOORD);
     _builtinAttributeLocation[Attribute::TEXCOORD] = location;
 
+    // a_normal
+    location                                     = glGetAttribLocation(_program, ATTRIBUTE_NAME_NORMAL);
+    _builtinAttributeLocation[Attribute::NORMAL] = location;
+
     /// u_MVPMatrix
     location                                                 = glGetUniformLocation(_program, UNIFORM_NAME_MVP_MATRIX);
     _builtinUniformLocation[Uniform::MVP_MATRIX].location[0] = location;
@@ -196,6 +201,11 @@ void ProgramGL::computeLocations()
     /// u_tex1
     location                                               = glGetUniformLocation(_program, UNIFORM_NAME_TEXTURE1);
     _builtinUniformLocation[Uniform::TEXTURE1].location[0] = location;
+}
+
+void ProgramGL::setupVertexLayout()
+{
+    _vertexLayout = new VertexLayout();
 }
 
 bool ProgramGL::getAttributeLocation(std::string_view attributeName, unsigned int& location) const

--- a/core/renderer/backend/opengl/ProgramGL.cpp
+++ b/core/renderer/backend/opengl/ProgramGL.cpp
@@ -221,20 +221,18 @@ bool ProgramGL::getAttributeLocation(std::string_view attributeName, unsigned in
     return true;
 }
 
-const hlookup::string_map<AttributeBindInfo> ProgramGL::getActiveAttributes() const
+const hlookup::string_map<AttributeBindInfo>& ProgramGL::getActiveAttributes() const
 {
-    hlookup::string_map<AttributeBindInfo> attributes;
-
-    if (!_program)
-        return attributes;
+    if (!_program || !_activeAttribs.empty())
+        return _activeAttribs;
 
     GLint numOfActiveAttributes = 0;
     glGetProgramiv(_program, GL_ACTIVE_ATTRIBUTES, &numOfActiveAttributes);
 
     if (numOfActiveAttributes <= 0)
-        return attributes;
+        return _activeAttribs;
 
-    attributes.reserve(numOfActiveAttributes);
+    _activeAttribs.reserve(numOfActiveAttributes);
 
     int MAX_ATTRIBUTE_NAME_LENGTH = 256;
     std::vector<char> attrName(MAX_ATTRIBUTE_NAME_LENGTH + 1);
@@ -253,10 +251,10 @@ const hlookup::string_map<AttributeBindInfo> ProgramGL::getActiveAttributes() co
         info.type          = attrType;
         info.size          = UtilsGL::getGLDataTypeSize(attrType) * attrSize;
         CHECK_GL_ERROR_DEBUG();
-        attributes[info.attributeName] = info;
+        _activeAttribs[info.attributeName] = info;
     }
 
-    return attributes;
+    return _activeAttribs;
 }
 
 void ProgramGL::computeUniformInfos()

--- a/core/renderer/backend/opengl/ProgramGL.h
+++ b/core/renderer/backend/opengl/ProgramGL.h
@@ -156,6 +156,7 @@ private:
     bool getAttributeLocation(std::string_view attributeName, unsigned int& location) const;
     void computeUniformInfos();
     void computeLocations();
+    void setupVertexLayout();
 #if AX_ENABLE_CACHE_TEXTURE_DATA
     virtual void reloadProgram();
     virtual int getMappedLocation(int location) const override;

--- a/core/renderer/backend/opengl/ProgramGL.h
+++ b/core/renderer/backend/opengl/ProgramGL.h
@@ -128,7 +128,7 @@ public:
      * Get active vertex attributes.
      * @return Active vertex attributes. key is active attribute name, Value is corresponding attribute info.
      */
-    virtual const hlookup::string_map<AttributeBindInfo> getActiveAttributes() const override;
+    virtual const hlookup::string_map<AttributeBindInfo>& getActiveAttributes() const override;
 
     /**
      * Get uniform buffer size in bytes that can hold all the uniforms.
@@ -173,6 +173,7 @@ private:
 
     std::vector<AttributeInfo> _attributeInfos;
     hlookup::string_map<UniformInfo> _activeUniformInfos;
+    mutable hlookup::string_map<AttributeBindInfo> _activeAttribs;
 #if AX_ENABLE_CACHE_TEXTURE_DATA
     std::unordered_map<std::string, int>
         _originalUniformLocations;  ///< record the uniform location when shader was first created.

--- a/core/ui/UIVideoPlayer/UIVideoPlayer-win.cpp
+++ b/core/ui/UIVideoPlayer/UIVideoPlayer-win.cpp
@@ -433,7 +433,7 @@ void VideoPlayer::draw(Renderer* renderer, const Mat4& transform, uint32_t flags
                     programCache->registerCustomProgramFactory(
                         VIDEO_PROGRAM_ID, positionTextureColor_vert,
                         std::string{pvd->_sampleFormat == VideoSampleFormat::NV12 ? NV12_FRAG : YUY2_FRAG},
-                        backend::VertexLayoutHelper::setupForSprite);
+                        backend::VertexLayoutHelper::setupSprite);
                     auto program = programCache->getCustomProgram(VIDEO_PROGRAM_ID);
                     pvd->_vrender->setProgramState(new backend::ProgramState(program), false);
                     break;

--- a/core/ui/UIVideoPlayer/UIVideoPlayer-win.cpp
+++ b/core/ui/UIVideoPlayer/UIVideoPlayer-win.cpp
@@ -432,7 +432,8 @@ void VideoPlayer::draw(Renderer* renderer, const Mat4& transform, uint32_t flags
                 {
                     programCache->registerCustomProgramFactory(
                         VIDEO_PROGRAM_ID, positionTextureColor_vert,
-                        std::string{pvd->_sampleFormat == VideoSampleFormat::NV12 ? NV12_FRAG : YUY2_FRAG});
+                        std::string{pvd->_sampleFormat == VideoSampleFormat::NV12 ? NV12_FRAG : YUY2_FRAG},
+                        backend::VertexLayoutHelper::setupForSprite);
                     auto program = programCache->getCustomProgram(VIDEO_PROGRAM_ID);
                     pvd->_vrender->setProgramState(new backend::ProgramState(program), false);
                     break;

--- a/extensions/ImGui/imgui_impl_axys.cpp
+++ b/extensions/ImGui/imgui_impl_axys.cpp
@@ -1467,7 +1467,7 @@ static bool ImGui_ImplAxys_createShaderPrograms()
         layout.setAttribute("a_position", p->position, VertexFormat::FLOAT2, 0, false);
         layout.setAttribute("a_texCoord", p->uv, VertexFormat::FLOAT2, offsetof(ImDrawVert, uv), false);
         layout.setAttribute("a_color", p->color, VertexFormat::UBYTE4, offsetof(ImDrawVert, col), true);
-        layout.setLayout(sizeof(ImDrawVert));
+        layout.setStride(sizeof(ImDrawVert));
     }
 
     return true;
@@ -1652,7 +1652,7 @@ IMGUI_IMPL_API void ImGui_ImplAxys_RenderDrawData(ImDrawData* draw_data)
                         auto& desc        = cmd->getPipelineDescriptor();
                         desc.programState = state;
                         // setup attributes for ImDrawVert
-                        *desc.programState->getVertexLayout() = pinfo->layout;
+                        desc.programState->setVertexLayout(pinfo->layout);
                         desc.programState->setUniform(pinfo->projection, &bd->Projection, sizeof(Mat4));
                         desc.programState->setTexture(pinfo->texture, 0, tex->getBackendTexture());
                         // In order to composite our output buffer we need to preserve alpha

--- a/extensions/Live2D/Framework/src/Rendering/axys/CubismRenderer_Cocos2dx.cpp
+++ b/extensions/Live2D/Framework/src/Rendering/axys/CubismRenderer_Cocos2dx.cpp
@@ -1350,9 +1350,9 @@ void CubismShader_Cocos2dx::SetupShaderProgram(CubismCommandBuffer_Cocos2dx::Dra
         programState->setTexture(shaderSet->SamplerTexture0Location, 0, texture->getBackendTexture());
 
         // 頂点配列の設定
-        programState->getVertexLayout()->setAttribute("a_position", shaderSet->AttributePositionLocation, ax::backend::VertexFormat::FLOAT2, 0, false);
+        programState->setVertexAttrib("a_position", shaderSet->AttributePositionLocation, ax::backend::VertexFormat::FLOAT2, 0, false);
         // テクスチャ頂点の設定
-        programState->getVertexLayout()->setAttribute("a_texCoord", shaderSet->AttributeTexCoordLocation, ax::backend::VertexFormat::FLOAT2, sizeof(csmFloat32) * 2, false);
+        programState->setVertexAttrib("a_texCoord", shaderSet->AttributeTexCoordLocation, ax::backend::VertexFormat::FLOAT2, sizeof(csmFloat32) * 2, false);
 
         // チャンネル
         const csmInt32 channelNo = renderer->GetClippingContextBufferForMask()->_layoutChannelNo;
@@ -1417,9 +1417,9 @@ void CubismShader_Cocos2dx::SetupShaderProgram(CubismCommandBuffer_Cocos2dx::Dra
         }
 
         // 頂点配列の設定
-        programState->getVertexLayout()->setAttribute("a_position", shaderSet->AttributePositionLocation, ax::backend::VertexFormat::FLOAT2, 0, false);
+        programState->setVertexAttrib("a_position", shaderSet->AttributePositionLocation, ax::backend::VertexFormat::FLOAT2, 0, false);
         // テクスチャ頂点の設定
-        programState->getVertexLayout()->setAttribute("a_texCoord", shaderSet->AttributeTexCoordLocation, ax::backend::VertexFormat::FLOAT2, sizeof(csmFloat32) * 2, false);
+        programState->setVertexAttrib("a_texCoord", shaderSet->AttributeTexCoordLocation, ax::backend::VertexFormat::FLOAT2, sizeof(csmFloat32) * 2, false);
 
         if (masked)
         {
@@ -1450,7 +1450,7 @@ void CubismShader_Cocos2dx::SetupShaderProgram(CubismCommandBuffer_Cocos2dx::Dra
         programState->setUniform(shaderSet->UniformBaseColorLocation, base, sizeof(float) * 4);
     }
 
-    programState->getVertexLayout()->setLayout(sizeof(csmFloat32) * 4);
+    programState->setVertexStride(sizeof(csmFloat32) * 4);
     blendDescriptor->blendEnabled = true;
     pipelineDescriptor->programState = programState;
 }

--- a/extensions/Particle3D/CCParticle3DRender.cpp
+++ b/extensions/Particle3D/CCParticle3DRender.cpp
@@ -214,27 +214,6 @@ bool Particle3DQuadRender::initQuadRender(std::string_view texFile)
 
     auto& pipelineDescriptor        = _meshCommand.getPipelineDescriptor();
     pipelineDescriptor.programState = _programState;
-    auto layout                     = _programState->getVertexLayout();
-    const auto& attributeInfo       = _programState->getProgram()->getActiveAttributes();
-    auto iter                       = attributeInfo.find("a_position");
-    if (iter != attributeInfo.end())
-    {
-        layout->setAttribute("a_position", iter->second.location, backend::VertexFormat::FLOAT3,
-                             offsetof(posuvcolor, position), false);
-    }
-    iter = attributeInfo.find("a_texCoord");
-    if (iter != attributeInfo.end())
-    {
-        layout->setAttribute("a_texCoord", iter->second.location, backend::VertexFormat::FLOAT2,
-                             offsetof(posuvcolor, uv), false);
-    }
-    iter = attributeInfo.find("a_color");
-    if (iter != attributeInfo.end())
-    {
-        layout->setAttribute("a_color", iter->second.location, backend::VertexFormat::FLOAT4,
-                             offsetof(posuvcolor, color), false);
-    }
-    layout->setLayout(sizeof(posuvcolor));
 
     _locColor   = _programState->getUniformLocation("u_color");
     _locPMatrix = _programState->getUniformLocation("u_PMatrix");

--- a/extensions/Particle3D/PU/CCPUBillboardChain.cpp
+++ b/extensions/Particle3D/PU/CCPUBillboardChain.cpp
@@ -650,27 +650,6 @@ void PUBillboardChain::init(std::string_view texFile)
 
     auto& pipelineDescriptor        = _meshCommand.getPipelineDescriptor();
     pipelineDescriptor.programState = _programState;
-    auto layout                     = _programState->getVertexLayout();
-    const auto& attributeInfo       = _programState->getProgram()->getActiveAttributes();
-    auto iter                       = attributeInfo.find("a_position");
-    if (iter != attributeInfo.end())
-    {
-        layout->setAttribute("a_position", iter->second.location, backend::VertexFormat::FLOAT3,
-                             offsetof(VertexInfo, position), false);
-    }
-    iter = attributeInfo.find("a_texCoord");
-    if (iter != attributeInfo.end())
-    {
-        layout->setAttribute("a_texCoord", iter->second.location, backend::VertexFormat::FLOAT2,
-                             offsetof(VertexInfo, uv), false);
-    }
-    iter = attributeInfo.find("a_color");
-    if (iter != attributeInfo.end())
-    {
-        layout->setAttribute("a_color", iter->second.location, backend::VertexFormat::FLOAT4,
-                             offsetof(VertexInfo, color), false);
-    }
-    layout->setLayout(sizeof(VertexInfo));
 
     _locColor   = _programState->getUniformLocation("u_color");
     _locPMatrix = _programState->getUniformLocation("u_PMatrix");

--- a/extensions/Particle3D/PU/CCPURender.cpp
+++ b/extensions/Particle3D/PU/CCPURender.cpp
@@ -635,27 +635,6 @@ bool PUParticle3DEntityRender::initRender(std::string_view texFile)
 
     auto& pipelineDescriptor        = _meshCommand.getPipelineDescriptor();
     pipelineDescriptor.programState = _programState;
-    auto layout                     = _programState->getVertexLayout();
-    const auto& attributeInfo       = _programState->getProgram()->getActiveAttributes();
-    auto iter                       = attributeInfo.find("a_position");
-    if (iter != attributeInfo.end())
-    {
-        layout->setAttribute("a_position", iter->second.location, backend::VertexFormat::FLOAT3,
-                             offsetof(VertexInfo, position), false);
-    }
-    iter = attributeInfo.find("a_texCoord");
-    if (iter != attributeInfo.end())
-    {
-        layout->setAttribute("a_texCoord", iter->second.location, backend::VertexFormat::FLOAT2,
-                             offsetof(VertexInfo, uv), false);
-    }
-    iter = attributeInfo.find("a_color");
-    if (iter != attributeInfo.end())
-    {
-        layout->setAttribute("a_color", iter->second.location, backend::VertexFormat::FLOAT4,
-                             offsetof(VertexInfo, color), false);
-    }
-    layout->setLayout(sizeof(VertexInfo));
 
     _locColor   = _programState->getUniformLocation("u_color");
     _locPMatrix = _programState->getUniformLocation("u_PMatrix");

--- a/extensions/cocostudio/ActionTimeline/CCBoneNode.cpp
+++ b/extensions/cocostudio/ActionTimeline/CCBoneNode.cpp
@@ -77,22 +77,6 @@ bool BoneNode::init()
 
     _mvpLocation = _programState->getUniformLocation("u_MVPMatrix"sv);
 
-    auto vertexLayout         = _programState->getVertexLayout();
-    const auto& attributeInfo = _programState->getProgram()->getActiveAttributes();
-    auto iter                 = attributeInfo.find("a_position"sv);
-    if (iter != attributeInfo.end())
-    {
-        vertexLayout->setAttribute("a_position"sv, iter->second.location, ax::backend::VertexFormat::FLOAT3, 0,
-                                   false);
-    }
-    iter = attributeInfo.find("a_color"sv);
-    if (iter != attributeInfo.end())
-    {
-        vertexLayout->setAttribute("a_color"sv, iter->second.location, ax::backend::VertexFormat::FLOAT4,
-                                   3 * sizeof(float), false);
-    }
-    vertexLayout->setLayout(7 * sizeof(float));
-
     _customCommand.createVertexBuffer(sizeof(_vertexData[0]), 4, ax::CustomCommand::BufferUsage::DYNAMIC);
     _customCommand.createIndexBuffer(ax::CustomCommand::IndexFormat::U_SHORT, 6,
                                      ax::CustomCommand::BufferUsage::STATIC);

--- a/extensions/cocostudio/ActionTimeline/CCSkeletonNode.cpp
+++ b/extensions/cocostudio/ActionTimeline/CCSkeletonNode.cpp
@@ -58,22 +58,6 @@ bool SkeletonNode::init()
 
     _mvpLocation = _programState->getUniformLocation("u_MVPMatrix");
 
-    auto vertexLayout         = _programState->getVertexLayout();
-    const auto& attributeInfo = _programState->getProgram()->getActiveAttributes();
-    auto iter                 = attributeInfo.find("a_position");
-    if (iter != attributeInfo.end())
-    {
-        vertexLayout->setAttribute("a_position", iter->second.location, ax::backend::VertexFormat::FLOAT3, 0,
-                                   false);
-    }
-    iter = attributeInfo.find("a_color");
-    if (iter != attributeInfo.end())
-    {
-        vertexLayout->setAttribute("a_color", iter->second.location, ax::backend::VertexFormat::FLOAT4,
-                                   3 * sizeof(float), false);
-    }
-    vertexLayout->setLayout(7 * sizeof(float));
-
     _customCommand.createVertexBuffer(sizeof(_vertexData[0]), 8, ax::CustomCommand::BufferUsage::DYNAMIC);
     _customCommand.createIndexBuffer(ax::CustomCommand::IndexFormat::U_SHORT, 12,
                                      ax::CustomCommand::BufferUsage::STATIC);

--- a/extensions/scripting/lua-bindings/auto/axlua_backend_auto.cpp
+++ b/extensions/scripting/lua-bindings/auto/axlua_backend_auto.cpp
@@ -1048,56 +1048,6 @@ int lua_ax_backend_VertexLayout_isValid(lua_State* tolua_S)
 
     return 0;
 }
-int lua_ax_backend_VertexLayout_setLayout(lua_State* tolua_S)
-{
-    int argc = 0;
-    ax::backend::VertexLayout* cobj = nullptr;
-    bool ok  = true;
-
-#if _AX_DEBUG >= 1
-    tolua_Error tolua_err;
-#endif
-
-
-#if _AX_DEBUG >= 1
-    if (!tolua_isusertype(tolua_S,1,"axb.VertexLayout",0,&tolua_err)) goto tolua_lerror;
-#endif
-
-    cobj = (ax::backend::VertexLayout*)tolua_tousertype(tolua_S,1,0);
-
-#if _AX_DEBUG >= 1
-    if (!cobj) 
-    {
-        tolua_error(tolua_S,"invalid 'cobj' in function 'lua_ax_backend_VertexLayout_setLayout'", nullptr);
-        return 0;
-    }
-#endif
-
-    argc = lua_gettop(tolua_S)-1;
-    if (argc == 1) 
-    {
-        unsigned int arg0;
-
-        ok &= luaval_to_uint32(tolua_S, 2,&arg0, "axb.VertexLayout:setLayout");
-        if(!ok)
-        {
-            tolua_error(tolua_S,"invalid arguments in function 'lua_ax_backend_VertexLayout_setLayout'", nullptr);
-            return 0;
-        }
-        cobj->setLayout(arg0);
-        lua_settop(tolua_S, 1);
-        return 1;
-    }
-    luaL_error(tolua_S, "%s has wrong number of arguments: %d, was expecting %d \n", "axb.VertexLayout:setLayout",argc, 1);
-    return 0;
-
-#if _AX_DEBUG >= 1
-    tolua_lerror:
-    tolua_error(tolua_S,"#ferror in function 'lua_ax_backend_VertexLayout_setLayout'.",&tolua_err);
-#endif
-
-    return 0;
-}
 int lua_ax_backend_VertexLayout_setAttribute(lua_State* tolua_S)
 {
     int argc = 0;
@@ -1257,7 +1207,6 @@ int lua_register_ax_backend_VertexLayout(lua_State* tolua_S)
         tolua_function(tolua_S,"new",lua_ax_backend_VertexLayout_constructor);
         tolua_function(tolua_S,"getVertexStepMode",lua_ax_backend_VertexLayout_getVertexStepMode);
         tolua_function(tolua_S,"isValid",lua_ax_backend_VertexLayout_isValid);
-        tolua_function(tolua_S,"setLayout",lua_ax_backend_VertexLayout_setLayout);
         tolua_function(tolua_S,"setAttribute",lua_ax_backend_VertexLayout_setAttribute);
         tolua_function(tolua_S,"getStride",lua_ax_backend_VertexLayout_getStride);
     tolua_endmodule(tolua_S);

--- a/extensions/spine/SkeletonBatch.cpp
+++ b/extensions/spine/SkeletonBatch.cpp
@@ -95,16 +95,6 @@ backend::ProgramState* SkeletonBatch::updateCommandPipelinePS(SkeletonCommand* c
 		AX_SAFE_RELEASE(currentState);
 		currentState = programState->clone();
 		
-		auto vertexLayout = currentState->getVertexLayout();
-        auto locPosition  = currentState->getAttributeLocation(backend::ATTRIBUTE_NAME_POSITION);
-        auto locTexcoord  = currentState->getAttributeLocation(backend::ATTRIBUTE_NAME_TEXCOORD);
-        auto locColor     = currentState->getAttributeLocation(backend::ATTRIBUTE_NAME_COLOR);
-		vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_POSITION, locPosition, backend::VertexFormat::FLOAT3, offsetof(V3F_C4B_T2F, vertices), false);
-		vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_COLOR, locColor, backend::VertexFormat::UBYTE4, offsetof(V3F_C4B_T2F, colors), true);
-		vertexLayout->setAttribute(backend::ATTRIBUTE_NAME_TEXCOORD, locTexcoord, backend::VertexFormat::FLOAT2, offsetof(V3F_C4B_T2F, texCoords), false);
-		vertexLayout->setLayout(sizeof(_vertices[0]));
-
-
 		command->_locMVP     = currentState->getUniformLocation(backend::UNIFORM_NAME_MVP_MATRIX);
         command->_locTexture = currentState->getUniformLocation(backend::UNIFORM_NAME_TEXTURE);
 	}

--- a/extensions/spine/SkeletonTwoColorBatch.cpp
+++ b/extensions/spine/SkeletonTwoColorBatch.cpp
@@ -103,18 +103,16 @@ namespace {
         __locPMatrix = programState->getUniformLocation("u_PMatrix");
         __locTexture = programState->getUniformLocation("u_texture");
 
-        auto layout = programState->getVertexLayout();
-
         auto locPosition = programState->getAttributeLocation("a_position");
         auto locTexcoord = programState->getAttributeLocation("a_texCoords");
         auto locColor = programState->getAttributeLocation("a_color");
         auto locColor2 = programState->getAttributeLocation("a_color2");
 
-        layout->setAttribute("a_position", locPosition, backend::VertexFormat::FLOAT3, offsetof(spine::V3F_C4B_C4B_T2F, position), false);
-        layout->setAttribute("a_color", locColor, backend::VertexFormat::UBYTE4, offsetof(spine::V3F_C4B_C4B_T2F, color), true);
-        layout->setAttribute("a_color2", locColor2, backend::VertexFormat::UBYTE4, offsetof(spine::V3F_C4B_C4B_T2F, color2), true);
-        layout->setAttribute("a_texCoords", locTexcoord, backend::VertexFormat::FLOAT2, offsetof(spine::V3F_C4B_C4B_T2F, texCoords), false);
-        layout->setLayout(sizeof(spine::V3F_C4B_C4B_T2F));
+        programState->setVertexAttrib("a_position", locPosition, backend::VertexFormat::FLOAT3, offsetof(spine::V3F_C4B_C4B_T2F, position), false);
+        programState->setVertexAttrib("a_color", locColor, backend::VertexFormat::UBYTE4, offsetof(spine::V3F_C4B_C4B_T2F, color), true);
+        programState->setVertexAttrib("a_color2", locColor2, backend::VertexFormat::UBYTE4, offsetof(spine::V3F_C4B_C4B_T2F, color2), true);
+        programState->setVertexAttrib("a_texCoords", locTexcoord, backend::VertexFormat::FLOAT2, offsetof(spine::V3F_C4B_C4B_T2F, texCoords), false);
+        programState->setVertexStride(sizeof(spine::V3F_C4B_C4B_T2F));
     }
 
     static void initTwoColorProgramState()

--- a/tests/cpp-tests/Classes/ClippingNodeTest/ClippingNodeTest.cpp
+++ b/tests/cpp-tests/Classes/ClippingNodeTest/ClippingNodeTest.cpp
@@ -591,12 +591,6 @@ void RawStencilBufferTest::initCommands()
         cmd.createIndexBuffer(backend::IndexFormat::U_SHORT, 6, backend::BufferUsage::STATIC);
         cmd.updateIndexBuffer(indices, sizeof(indices));
         cmd.getPipelineDescriptor().programState = _programState;
-        auto vertexLayout                        = _programState->getVertexLayout();
-        auto& attributes                         = _programState->getProgram()->getActiveAttributes();
-        auto iter                                = attributes.find("a_position");
-        if (iter != attributes.end())
-            vertexLayout->setAttribute("a_position", iter->second.location, backend::VertexFormat::FLOAT2, 0, false);
-        vertexLayout->setLayout(sizeof(Vec2));
 
         auto& cmd2 = _renderCmds[cmdIndex];
         cmdIndex++;

--- a/tests/cpp-tests/Classes/MeshRendererTest/DrawNode3D.cpp
+++ b/tests/cpp-tests/Classes/MeshRendererTest/DrawNode3D.cpp
@@ -82,7 +82,6 @@ bool DrawNode3D::init()
     _customCommand.setBeforeCallback(AX_CALLBACK_0(DrawNode3D::onBeforeDraw, this));
     _customCommand.setAfterCallback(AX_CALLBACK_0(DrawNode3D::onAfterDraw, this));
 
-    auto layout = _programStateLine->getVertexLayout();
 #define INITIAL_VERTEX_BUFFER_LENGTH 512
 
     ensureCapacity(INITIAL_VERTEX_BUFFER_LENGTH);

--- a/tests/cpp-tests/Classes/MeshRendererTest/DrawNode3D.cpp
+++ b/tests/cpp-tests/Classes/MeshRendererTest/DrawNode3D.cpp
@@ -90,19 +90,6 @@ bool DrawNode3D::init()
     _customCommand.setDrawType(CustomCommand::DrawType::ARRAY);
     _customCommand.setPrimitiveType(CustomCommand::PrimitiveType::LINE);
 
-    const auto& attributeInfo = _programStateLine->getProgram()->getActiveAttributes();
-    auto iter                 = attributeInfo.find("a_position");
-    if (iter != attributeInfo.end())
-    {
-        layout->setAttribute("a_position", iter->second.location, backend::VertexFormat::FLOAT3, 0, false);
-    }
-    iter = attributeInfo.find("a_color");
-    if (iter != attributeInfo.end())
-    {
-        layout->setAttribute("a_color", iter->second.location, backend::VertexFormat::UBYTE4, sizeof(Vec3), true);
-    }
-    layout->setLayout(sizeof(V3F_C4B));
-
     _customCommand.createVertexBuffer(sizeof(V3F_C4B), INITIAL_VERTEX_BUFFER_LENGTH,
                                       CustomCommand::BufferUsage::DYNAMIC);
     _isDirty = true;

--- a/tests/cpp-tests/Classes/MeshRendererTest/DrawNode3D.h
+++ b/tests/cpp-tests/Classes/MeshRendererTest/DrawNode3D.h
@@ -90,11 +90,6 @@ protected:
     void onBeforeDraw();
     void onAfterDraw();
 
-    struct V3F_C4B
-    {
-        axis::Vec3 vertices;
-        Color4B colors;
-    };
     void ensureCapacity(int count);
 
     BlendFunc _blendFunc;

--- a/tests/cpp-tests/Classes/NewRendererTest/NewRendererTest.cpp
+++ b/tests/cpp-tests/Classes/NewRendererTest/NewRendererTest.cpp
@@ -77,11 +77,11 @@ NewRendererTests::NewRendererTests()
     auto programCache = backend::ProgramCache::getInstance();
     programCache->registerCustomProgramFactory(CustomProgramType::BLUR, positionTextureColor_vert,
                                                FileUtils::getInstance()->getStringFromFile("Shaders/example_Blur.fsh"),
-                                               backend::VertexLayoutHelper::setupForSprite);
+                                               backend::VertexLayoutHelper::setupSprite);
     programCache->registerCustomProgramFactory(
         CustomProgramType::SEPIA, positionTextureColor_vert,
                                                FileUtils::getInstance()->getStringFromFile("Shaders/example_Sepia.fsh"),
-                                               backend::VertexLayoutHelper::setupForSprite);
+                                               backend::VertexLayoutHelper::setupSprite);
 
     ADD_TEST_CASE(NewSpriteTest);
     ADD_TEST_CASE(GroupCommandTest);

--- a/tests/cpp-tests/Classes/NewRendererTest/NewRendererTest.cpp
+++ b/tests/cpp-tests/Classes/NewRendererTest/NewRendererTest.cpp
@@ -76,10 +76,12 @@ NewRendererTests::NewRendererTests()
 {
     auto programCache = backend::ProgramCache::getInstance();
     programCache->registerCustomProgramFactory(CustomProgramType::BLUR, positionTextureColor_vert,
-                                               FileUtils::getInstance()->getStringFromFile("Shaders/example_Blur.fsh"));
+                                               FileUtils::getInstance()->getStringFromFile("Shaders/example_Blur.fsh"),
+                                               backend::VertexLayoutHelper::setupForSprite);
     programCache->registerCustomProgramFactory(
         CustomProgramType::SEPIA, positionTextureColor_vert,
-        FileUtils::getInstance()->getStringFromFile("Shaders/example_Sepia.fsh"));
+                                               FileUtils::getInstance()->getStringFromFile("Shaders/example_Sepia.fsh"),
+                                               backend::VertexLayoutHelper::setupForSprite);
 
     ADD_TEST_CASE(NewSpriteTest);
     ADD_TEST_CASE(GroupCommandTest);

--- a/tests/cpp-tests/Classes/Physics3DTest/Physics3DTest.cpp
+++ b/tests/cpp-tests/Classes/Physics3DTest/Physics3DTest.cpp
@@ -700,7 +700,7 @@ bool Physics3DCollisionCallbackDemo::init()
         Physics3DRigidBodyDes rbDes;
 
         float scale = 2.0f;
-        std::vector<Vec3> trianglesList = Bundle3D::getTrianglesList("MeshRendererTest/boss.c3b");
+        std::vector<Vec3> trianglesList = Bundle3D::getTrianglesList("MeshRendererTest/boss.obj");
         for (auto&& it : trianglesList)
         {
             it *= scale;
@@ -710,7 +710,7 @@ bool Physics3DCollisionCallbackDemo::init()
         rbDes.shape = Physics3DShape::createMesh(&trianglesList[0], (int)trianglesList.size() / 3);
         auto rigidBody = Physics3DRigidBody::create(&rbDes);
         auto component = Physics3DComponent::create(rigidBody);
-        auto mesh = MeshRenderer::create("MeshRendererTest/boss.c3b");
+        auto mesh = MeshRenderer::create("MeshRendererTest/boss.obj", "MeshRendererTest/boss.png");
         mesh->addComponent(component);
         mesh->setRotation3D(Vec3(-90.0f, 0.0f, 0.0f));
         mesh->setScale(scale);
@@ -727,7 +727,7 @@ bool Physics3DCollisionCallbackDemo::init()
                     ps->setPosition3D(ci.collisionPointList[0].worldPositionOnB);
                     ps->setScale(0.05f);
                     ps->startParticleSystem();
-                    ps->setCameraMask(2);
+                    ps->setCameraMask((unsigned short)CameraFlag::USER1);
                     this->addChild(ps);
                     ps->runAction(Sequence::create(DelayTime::create(1.0f),
                                                    CallFunc::create([=]() { ps->removeFromParent(); }), nullptr));

--- a/tests/cpp-tests/Classes/ShaderTest/ShaderTest.cpp
+++ b/tests/cpp-tests/Classes/ShaderTest/ShaderTest.cpp
@@ -104,11 +104,11 @@ bool ShaderNode::initWithVertex(std::string_view vert, std::string_view frag)
     // init custom command
     auto layout     = _programState->getVertexLayout();
     auto attrPosLoc = _programState->getAttributeLocation("a_position");
-    layout->setAttribute("a_position", attrPosLoc, backend::VertexFormat::FLOAT2, 0, false);
+    _programState->setVertexAttrib("a_position", attrPosLoc, backend::VertexFormat::FLOAT2, 0, false);
 
     float w = SIZE_X, h = SIZE_Y;
     Vec2 vertices[6] = {Vec2(0.0f, 0.0f), Vec2(w, 0.0f), Vec2(w, h), Vec2(0.0f, 0.0f), Vec2(0.0f, h), Vec2(w, h)};
-    layout->setLayout(sizeof(Vec2));
+    _programState->setVertexStride(sizeof(Vec2));
 
     /*
      * TODO: the Y-coordinate of subclasses are flipped in metal

--- a/tests/cpp-tests/Classes/ShaderTest/ShaderTest.cpp
+++ b/tests/cpp-tests/Classes/ShaderTest/ShaderTest.cpp
@@ -102,7 +102,6 @@ bool ShaderNode::initWithVertex(std::string_view vert, std::string_view frag)
     setAnchorPoint(Vec2(0.5f, 0.5f));
 
     // init custom command
-    auto layout     = _programState->getVertexLayout();
     auto attrPosLoc = _programState->getAttributeLocation("a_position");
     _programState->setVertexAttrib("a_position", attrPosLoc, backend::VertexFormat::FLOAT2, 0, false);
 

--- a/tests/live2d-tests/Classes/LAppSprite.cpp
+++ b/tests/live2d-tests/Classes/LAppSprite.cpp
@@ -63,15 +63,15 @@ void LAppSprite::RenderImmidiate(Csm::Rendering::CubismCommandBuffer_Cocos2dx* c
     }
 
     // attribute属性を登録
-    programState->getVertexLayout()->setAttribute("position", _program->getAttributeLocation("position"), backend::VertexFormat::FLOAT2, 0, false);
-    programState->getVertexLayout()->setAttribute("uv", _program->getAttributeLocation("uv"), backend::VertexFormat::FLOAT2, sizeof(float) * 2, false);
+    programState->setVertexAttrib("position", _program->getAttributeLocation("position"), backend::VertexFormat::FLOAT2, 0, false);
+    programState->setVertexAttrib("uv", _program->getAttributeLocation("uv"), backend::VertexFormat::FLOAT2, sizeof(float) * 2, false);
 
     // uniform属性の登録
     programState->setTexture(_program->getUniformLocation("texture"), 0, texture);
 
     programState->setUniform(_program->getUniformLocation("baseColor"), _spriteColor, sizeof(float) * 4);
 
-    programState->getVertexLayout()->setLayout(sizeof(float) * 4);
+    programState->setVertexStride(sizeof(float) * 4);
 
     blendDescriptor->sourceRGBBlendFactor = axis::backend::BlendFactor::ONE;
     blendDescriptor->destinationRGBBlendFactor = axis::backend::BlendFactor::ONE_MINUS_SRC_ALPHA;

--- a/tests/lua-tests/project/Classes/lua_test_bindings.cpp
+++ b/tests/lua-tests/project/Classes/lua_test_bindings.cpp
@@ -155,19 +155,18 @@ bool DrawNode3D::init()
     _customCommand.setDrawType(CustomCommand::DrawType::ARRAY);
     _customCommand.setPrimitiveType(CustomCommand::PrimitiveType::LINE);
 
-    auto layout               = _programState->getVertexLayout();
     const auto& attributeInfo = _programState->getProgram()->getActiveAttributes();
     auto iter                 = attributeInfo.find("a_position");
     if (iter != attributeInfo.end())
     {
-        layout->setAttribute(iter->first, iter->second.location, backend::VertexFormat::FLOAT3, 0, false);
+        _programState->setVertexAttrib(iter->first, iter->second.location, backend::VertexFormat::FLOAT3, 0, false);
     }
     iter = attributeInfo.find("a_color");
     if (iter != attributeInfo.end())
     {
-        layout->setAttribute(iter->first, iter->second.location, backend::VertexFormat::UBYTE4, sizeof(Vec3), true);
+        _programState->setVertexAttrib(iter->first, iter->second.location, backend::VertexFormat::UBYTE4, sizeof(Vec3), true);
     }
-    layout->setLayout(sizeof(V3F_C4B));
+    _programState->setVertexStride(sizeof(V3F_C4B));
 
     _customCommand.createVertexBuffer(sizeof(V3F_C4B), INITIAL_VERTEX_BUFFER_LENGTH,
                                       CustomCommand::BufferUsage::DYNAMIC);


### PR DESCRIPTION
THIS PROJECT IS IN DEVELOPMENT MODE. Any pull requests should merge to branch `dev`, otherwise will be rejected immediately.

## Describe your changes
Refactor VertexLayout sharing mechanism.

- Move shared `VertexLayout` to  shader `Program`
- By default `ProgramState` share `VertexLayout` from `Program`
- Provide `setVertexAttrib` and `setVertexStride` for `ProgramState` to setup custom multable `VertexLayout`

## Issue ticket number and link
#861

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
